### PR TITLE
fix: use logical points instead of physical pixels

### DIFF
--- a/src/helpers/input-helper.ts
+++ b/src/helpers/input-helper.ts
@@ -22,7 +22,8 @@ export type InputCommand =
   | "scroll"
   | "drag"
   | "cursor"
-  | "secure";
+  | "secure"
+  | "display_info";
 
 /**
  * Execute the Swift input-helper binary with the given command and arguments.

--- a/src/helpers/screencapture.ts
+++ b/src/helpers/screencapture.ts
@@ -40,6 +40,8 @@ export interface CaptureOptions {
   maxDimension?: number;
   /** Output image format. Defaults to "png". */
   format?: ImageFormat;
+  /** Display scale factor (e.g. 2 for Retina). Defaults to 1. */
+  displayScaleFactor?: number;
 }
 
 /** Result of a screen capture operation. */
@@ -52,6 +54,10 @@ export interface ScreenshotResult {
   height: number;
   /** Description of the scaling applied. */
   scaleInfo: string;
+  /** Logical screen width in points (physical pixels / scaleFactor). */
+  screenWidth: number;
+  /** Logical screen height in points (physical pixels / scaleFactor). */
+  screenHeight: number;
 }
 
 /**
@@ -149,6 +155,7 @@ export async function captureScreen(
     windowTitle,
     maxDimension = DEFAULT_MAX_DIMENSION,
     format = "png",
+    displayScaleFactor = 1,
   } = options;
 
   const tmpPath = makeTmpPath(format);
@@ -191,8 +198,12 @@ export async function captureScreen(
       timeout: COMMAND_TIMEOUT_MS,
     });
 
-    // Get original dimensions before resizing
+    // Get original dimensions (physical pixels) before resizing
     const originalDims = await getImageDimensions(tmpPath);
+
+    // Compute logical dimensions (same coordinate system as CGEvent)
+    const logicalWidth = Math.round(originalDims.width / displayScaleFactor);
+    const logicalHeight = Math.round(originalDims.height / displayScaleFactor);
 
     // Resize to fit within maxDimension
     await execFileAsync("sips", ["-Z", String(maxDimension), tmpPath], {
@@ -203,9 +214,9 @@ export async function captureScreen(
     const finalDims = await getImageDimensions(tmpPath);
 
     const scaleInfo =
-      originalDims.width === finalDims.width && originalDims.height === finalDims.height
+      logicalWidth === finalDims.width && logicalHeight === finalDims.height
         ? `No resize needed (${finalDims.width}x${finalDims.height})`
-        : `Resized from ${originalDims.width}x${originalDims.height} to ${finalDims.width}x${finalDims.height}`;
+        : `Resized from ${logicalWidth}x${logicalHeight} to ${finalDims.width}x${finalDims.height}`;
 
     // Read file and encode to base64
     const buffer = await readFile(tmpPath);
@@ -216,6 +227,8 @@ export async function captureScreen(
       width: finalDims.width,
       height: finalDims.height,
       scaleInfo,
+      screenWidth: logicalWidth,
+      screenHeight: logicalHeight,
     };
   } finally {
     // Clean up temporary file

--- a/src/tools/screen.ts
+++ b/src/tools/screen.ts
@@ -1,39 +1,15 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { runInputHelper } from "../helpers/input-helper.js";
 import { enqueue } from "../queue.js";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-const execFileAsync = promisify(execFile);
-
-// -- Constants ---------------------------------------------------------------
-
-/** Timeout for system_profiler command (ms). */
-const SYSTEM_PROFILER_TIMEOUT_MS = 10_000;
-
 // -- Types -------------------------------------------------------------------
 
-/** Per-display information extracted from system_profiler output. */
+/** Per-display information returned by the Swift helper. */
 interface DisplayInfo {
   name: string;
   resolution: { width: number; height: number };
   origin: { x: number; y: number };
   scaleFactor: number;
-}
-
-/** system_profiler SPDisplaysDataType JSON structure (relevant fields). */
-interface SPDisplaysDataType {
-  SPDisplaysDataType: Array<{
-    sppci_model?: string;
-    _name?: string;
-    spdisplays_ndrvs?: Array<{
-      _name?: string;
-      _spdisplays_resolution?: string;
-      _spdisplays_pixels?: string;
-      spdisplays_resolution?: string;
-      _spdisplays_displayOrigin?: string;
-    }>;
-  }>;
 }
 
 // -- Tool definitions --------------------------------------------------------
@@ -68,72 +44,24 @@ export const screenToolDefinitions: Tool[] = [
 
 // -- Handlers ----------------------------------------------------------------
 
-/**
- * Parse resolution string from system_profiler into width, height, and scale.
- *
- * Common formats:
- *   "1920 x 1080"
- *   "3024 x 1964 Retina"
- *   "2560 x 1440 @ 2.00x"
- */
-function parseResolution(raw: string): {
-  width: number;
-  height: number;
-  retina: boolean;
-} {
-  const match = raw.match(/(\d+)\s*x\s*(\d+)/);
-  if (!match) {
-    return { width: 0, height: 0, retina: false };
-  }
-  const retina =
-    /retina/i.test(raw) || /@\s*2/i.test(raw);
-  return {
-    width: parseInt(match[1], 10),
-    height: parseInt(match[2], 10),
-    retina,
-  };
-}
-
-/**
- * Parse origin string like "(0, 0)" into x, y coordinates.
- */
-function parseOrigin(raw: string | undefined): { x: number; y: number } {
-  if (!raw) return { x: 0, y: 0 };
-  const match = raw.match(/\(?\s*(-?\d+)\s*,\s*(-?\d+)\s*\)?/);
-  if (!match) return { x: 0, y: 0 };
-  return { x: parseInt(match[1], 10), y: parseInt(match[2], 10) };
-}
-
 /** Handle get_screen_info tool call. */
 async function handleGetScreenInfo(): Promise<CallToolResult> {
-  const { stdout } = await execFileAsync(
-    "system_profiler",
-    ["SPDisplaysDataType", "-json"],
-    { timeout: SYSTEM_PROFILER_TIMEOUT_MS },
-  );
+  const response = await runInputHelper("display_info", {});
+  const rawDisplays = response.displays as Array<{
+    name: string;
+    width: number;
+    height: number;
+    x: number;
+    y: number;
+    scaleFactor: number;
+  }>;
 
-  const data = JSON.parse(stdout) as SPDisplaysDataType;
-  const displays: DisplayInfo[] = [];
-
-  for (const gpu of data.SPDisplaysDataType) {
-    const screens = gpu.spdisplays_ndrvs ?? [];
-    for (const screen of screens) {
-      const resString =
-        screen._spdisplays_pixels ??
-        screen._spdisplays_resolution ??
-        screen.spdisplays_resolution ??
-        "";
-      const { width, height, retina } = parseResolution(resString);
-      const origin = parseOrigin(screen._spdisplays_displayOrigin);
-
-      displays.push({
-        name: screen._name ?? "Unknown Display",
-        resolution: { width, height },
-        origin,
-        scaleFactor: retina ? 2 : 1,
-      });
-    }
-  }
+  const displays: DisplayInfo[] = rawDisplays.map((d) => ({
+    name: d.name,
+    resolution: { width: d.width, height: d.height },
+    origin: { x: d.x, y: d.y },
+    scaleFactor: d.scaleFactor,
+  }));
 
   const result = {
     displayCount: displays.length,

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { captureScreen } from "../helpers/screencapture.js";
+import { runInputHelper } from "../helpers/input-helper.js";
 import { enqueue } from "../queue.js";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -158,6 +159,11 @@ async function handleScreenshot(
   const parsed = ScreenshotInputSchema.parse(args);
 
   try {
+    // Get display scale factor for logical dimension computation
+    const displayResponse = await runInputHelper("display_info", {});
+    const displays = displayResponse.displays as Array<{ scaleFactor: number }>;
+    const scaleFactor = displays.length > 0 ? displays[0].scaleFactor : 1;
+
     const result = await captureScreen({
       mode: parsed.mode,
       region:
@@ -167,6 +173,7 @@ async function handleScreenshot(
       windowTitle: parsed.mode === "window" ? parsed.window_title : undefined,
       maxDimension: parsed.max_dimension,
       format: parsed.format,
+      displayScaleFactor: scaleFactor,
     });
 
     const mimeType = parsed.format === "jpeg" ? "image/jpeg" : "image/png";
@@ -181,10 +188,10 @@ async function handleScreenshot(
         {
           type: "text" as const,
           text: [
-            `Image dimensions: ${result.width}x${result.height} (logical pixels)`,
+            `Image dimensions: ${result.width}x${result.height} (pixels)`,
             `Scale: ${result.scaleInfo}`,
-            "Note: coordinates in this image map to screen coordinates at the same scale ratio. " +
-              "To convert image pixel positions to screen coordinates, multiply by (original_dimension / image_dimension).",
+            "Note: to convert image pixel positions to screen coordinates, " +
+              `multiply by (screen_dimension / image_dimension). Screen is ${result.screenWidth}x${result.screenHeight}.`,
           ].join("\n"),
         },
       ],

--- a/swift/input-helper.swift
+++ b/swift/input-helper.swift
@@ -376,6 +376,44 @@ func handleSecure() {
     outputJSON(["success": true, "secure": isSecure])
 }
 
+// MARK: - Display Info Handler
+
+/// Handle the "display_info" command.
+///
+/// Queries all active displays via CGDisplayBounds (logical points — same
+/// coordinate system as CGEvent) and the display scale factor.
+///
+/// Args: {} (none required)
+/// Returns: {"success":true, "displays":[{name, width, height, x, y, scaleFactor}]}
+func handleDisplayInfo() {
+    var displayIDs = [CGDirectDisplayID](repeating: 0, count: 32)
+    var displayCount: UInt32 = 0
+    CGGetActiveDisplayList(32, &displayIDs, &displayCount)
+
+    var displays: [[String: Any]] = []
+    for i in 0..<Int(displayCount) {
+        let id = displayIDs[i]
+        let bounds = CGDisplayBounds(id)
+
+        var scaleFactor = 1
+        if let mode = CGDisplayCopyDisplayMode(id) {
+            let pw = mode.pixelWidth
+            scaleFactor = Int(round(Double(pw) / Double(bounds.size.width)))
+        }
+
+        displays.append([
+            "name": CGDisplayIsBuiltin(id) != 0 ? "Built-in Display" : "External Display",
+            "width": Int(bounds.size.width),
+            "height": Int(bounds.size.height),
+            "x": Int(bounds.origin.x),
+            "y": Int(bounds.origin.y),
+            "scaleFactor": scaleFactor,
+        ])
+    }
+
+    outputJSON(["success": true, "displays": displays])
+}
+
 // MARK: - Main Entry Point
 
 let arguments = CommandLine.arguments
@@ -412,6 +450,8 @@ case "drag":
     handleDrag(args)
 case "secure":
     handleSecure()
+case "display_info":
+    handleDisplayInfo()
 default:
     fail("unknown command: \(command)")
 }


### PR DESCRIPTION
## Summary
- Add `display_info` command to Swift helper that queries `CGDisplayBounds` for logical point dimensions and scale factor
- Rewrite `get_screen_info` to use the new Swift command instead of `system_profiler`, returning logical coordinates matching the CGEvent coordinate system
- Pass display scale factor into screenshot capture so metadata reports logical dimensions and correct coordinate conversion instructions

## Test plan
- [ ] `pnpm run build:swift && pnpm build && pnpm lint` passes
- [ ] `get_screen_info` returns logical resolution (~1470x956 on 2x Retina) with scaleFactor=2
- [ ] `screenshot` scaleInfo shows logical dimensions (e.g. "Resized from 1470x956 to 1024x666")
- [ ] `get_cursor_position` values fall within `get_screen_info` resolution range
- [ ] Click accuracy: screenshot → identify element → click → verify hit