### PR TITLE
fix: security hardening, code quality, and macOS 26 keyboard compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "zod-to-json-schema": "^3.25.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       zod:
         specifier: ^3.24.2
         version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.25.1
+        version: 3.25.1(zod@3.25.76)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.3

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -108,6 +108,9 @@ export const MODIFIER_FLAGS = {
   control: 0x040000,
 } as const;
 
+/** Default maximum dimension (width or height) for screenshot resizing. */
+export const DEFAULT_MAX_DIMENSION = 1024;
+
 /**
  * Standardized error messages used across the MCP server.
  */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -111,6 +111,23 @@ export const MODIFIER_FLAGS = {
 /** Default maximum dimension (width or height) for screenshot resizing. */
 export const DEFAULT_MAX_DIMENSION = 1024;
 
+// -- Timeouts ----------------------------------------------------------------
+
+/** Timeout for AppleScript execution via osascript (ms). */
+export const APPLESCRIPT_TIMEOUT_MS = 15_000;
+
+/** Timeout for clipboard commands: pbpaste, pbcopy (ms). */
+export const CLIPBOARD_TIMEOUT_MS = 5_000;
+
+/** Timeout for screencapture and sips image-processing commands (ms). */
+export const SCREENCAPTURE_TIMEOUT_MS = 10_000;
+
+/** Timeout for Swift input-helper binary execution (ms). */
+export const INPUT_HELPER_TIMEOUT_MS = 5_000;
+
+/** Timeout for the `open` command in window management (ms). */
+export const OPEN_COMMAND_TIMEOUT_MS = 5_000;
+
 /**
  * Standardized error messages used across the MCP server.
  */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -128,6 +128,9 @@ export const INPUT_HELPER_TIMEOUT_MS = 5_000;
 /** Timeout for the `open` command in window management (ms). */
 export const OPEN_COMMAND_TIMEOUT_MS = 5_000;
 
+/** Timeout for permission check probes: accessibility and screen recording (ms). */
+export const PERMISSION_CHECK_TIMEOUT_MS = 5_000;
+
 /**
  * Standardized error messages used across the MCP server.
  */

--- a/src/helpers/applescript.ts
+++ b/src/helpers/applescript.ts
@@ -7,6 +7,18 @@ const execFileAsync = promisify(execFile);
 const COMMAND_TIMEOUT_MS = 15_000;
 
 /**
+ * Escape a string for safe interpolation inside AppleScript double-quoted literals.
+ *
+ * Escapes backslashes first, then double quotes (order matters).
+ *
+ * @param str - The raw string to escape.
+ * @returns The escaped string safe for use inside AppleScript `"..."`.
+ */
+export function escapeAppleScriptString(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
  * Execute an AppleScript expression and return its result.
  *
  * Uses the native `osascript` command with the `-e` flag.

--- a/src/helpers/applescript.ts
+++ b/src/helpers/applescript.ts
@@ -1,7 +1,4 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "./exec.js";
 
 /** Timeout for AppleScript execution (ms). */
 const COMMAND_TIMEOUT_MS = 15_000;

--- a/src/helpers/applescript.ts
+++ b/src/helpers/applescript.ts
@@ -1,7 +1,5 @@
 import { execFileAsync } from "./exec.js";
-
-/** Timeout for AppleScript execution (ms). */
-const COMMAND_TIMEOUT_MS = 15_000;
+import { APPLESCRIPT_TIMEOUT_MS } from "../constants.js";
 
 /**
  * Escape a string for safe interpolation inside AppleScript double-quoted literals.
@@ -28,7 +26,7 @@ export function escapeAppleScriptString(str: string): string {
 export async function runAppleScript(script: string): Promise<string> {
   try {
     const { stdout } = await execFileAsync("osascript", ["-e", script], {
-      timeout: COMMAND_TIMEOUT_MS,
+      timeout: APPLESCRIPT_TIMEOUT_MS,
     });
     return stdout.trim();
   } catch (error: unknown) {
@@ -41,7 +39,7 @@ export async function runAppleScript(script: string): Promise<string> {
 
     if (execError.killed || execError.signal === "SIGTERM") {
       throw new Error(
-        `AppleScript execution timed out after ${COMMAND_TIMEOUT_MS}ms`,
+        `AppleScript execution timed out after ${APPLESCRIPT_TIMEOUT_MS}ms`,
       );
     }
 

--- a/src/helpers/clipboard.ts
+++ b/src/helpers/clipboard.ts
@@ -1,7 +1,5 @@
 import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "./exec.js";
 
 /** Timeout for clipboard commands (ms). */
 const COMMAND_TIMEOUT_MS = 5_000;

--- a/src/helpers/clipboard.ts
+++ b/src/helpers/clipboard.ts
@@ -1,8 +1,6 @@
 import { execFile } from "node:child_process";
 import { execFileAsync } from "./exec.js";
-
-/** Timeout for clipboard commands (ms). */
-const COMMAND_TIMEOUT_MS = 5_000;
+import { CLIPBOARD_TIMEOUT_MS } from "../constants.js";
 
 /**
  * Read the current contents of the macOS clipboard as plain text.
@@ -14,7 +12,7 @@ const COMMAND_TIMEOUT_MS = 5_000;
  */
 export async function clipboardRead(): Promise<string> {
   const { stdout } = await execFileAsync("pbpaste", [], {
-    timeout: COMMAND_TIMEOUT_MS,
+    timeout: CLIPBOARD_TIMEOUT_MS,
   });
   return stdout;
 }
@@ -32,7 +30,7 @@ export async function clipboardWrite(text: string): Promise<void> {
     const proc = execFile(
       "pbcopy",
       [],
-      { timeout: COMMAND_TIMEOUT_MS },
+      { timeout: CLIPBOARD_TIMEOUT_MS },
       (error) => {
         if (error) {
           reject(error);

--- a/src/helpers/exec.ts
+++ b/src/helpers/exec.ts
@@ -1,0 +1,5 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+/** Promisified child_process.execFile for async/await usage. */
+export const execFileAsync = promisify(execFile);

--- a/src/helpers/input-helper.ts
+++ b/src/helpers/input-helper.ts
@@ -1,10 +1,7 @@
 import { access } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
-import { ERROR_MESSAGES } from "../constants.js";
+import { ERROR_MESSAGES, INPUT_HELPER_TIMEOUT_MS } from "../constants.js";
 import { execFileAsync } from "./exec.js";
-
-/** Timeout for Swift helper binary execution (ms). */
-const COMMAND_TIMEOUT_MS = 5_000;
 
 /** Path to the compiled Swift input-helper binary. */
 const BINARY_PATH = new URL("../../dist/bin/input-helper", import.meta.url)
@@ -49,7 +46,7 @@ export async function runInputHelper(
     const { stdout } = await execFileAsync(
       BINARY_PATH,
       [command, JSON.stringify(args)],
-      { timeout: COMMAND_TIMEOUT_MS },
+      { timeout: INPUT_HELPER_TIMEOUT_MS },
     );
 
     return JSON.parse(stdout) as Record<string, unknown>;

--- a/src/helpers/input-helper.ts
+++ b/src/helpers/input-helper.ts
@@ -17,7 +17,8 @@ export type InputCommand =
   | "drag"
   | "cursor"
   | "secure"
-  | "display_info";
+  | "display_info"
+  | "list_windows";
 
 /**
  * Execute the Swift input-helper binary with the given command and arguments.

--- a/src/helpers/input-helper.ts
+++ b/src/helpers/input-helper.ts
@@ -1,10 +1,7 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { access } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import { ERROR_MESSAGES } from "../constants.js";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "./exec.js";
 
 /** Timeout for Swift helper binary execution (ms). */
 const COMMAND_TIMEOUT_MS = 5_000;

--- a/src/helpers/schema.ts
+++ b/src/helpers/schema.ts
@@ -1,0 +1,16 @@
+import type { ZodObject, ZodRawShape } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Convert a Zod object schema to a JSON Schema compatible with the MCP Tool
+ * inputSchema type.
+ *
+ * zodToJsonSchema returns a broad union type, but z.object() always produces
+ * `{ type: "object", ... }` at runtime. This helper narrows the type.
+ */
+export function zodToToolInputSchema(
+  schema: ZodObject<ZodRawShape>,
+): Tool["inputSchema"] {
+  return zodToJsonSchema(schema) as Tool["inputSchema"];
+}

--- a/src/helpers/screencapture.ts
+++ b/src/helpers/screencapture.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { readFile, unlink } from "node:fs/promises";
 import { promisify } from "node:util";
 import { randomBytes } from "node:crypto";
+import { escapeAppleScriptString } from "./applescript.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -71,13 +72,14 @@ export interface ScreenshotResult {
  * @throws If no matching window is found.
  */
 async function getWindowId(windowTitle: string): Promise<string> {
+  const safeTitle = escapeAppleScriptString(windowTitle);
   const script = `
     tell application "System Events"
       set matchedId to ""
       repeat with proc in (every process whose background only is false)
         try
           repeat with w in (every window of proc)
-            if name of w contains "${windowTitle.replace(/"/g, '\\"')}" then
+            if name of w contains "${safeTitle}" then
               set matchedId to id of w
               exit repeat
             end if
@@ -85,7 +87,7 @@ async function getWindowId(windowTitle: string): Promise<string> {
         end try
         if matchedId is not "" then exit repeat
       end repeat
-      if matchedId is "" then error "No window found matching: ${windowTitle.replace(/"/g, '\\"')}"
+      if matchedId is "" then error "No window found matching: ${safeTitle}"
       return matchedId
     end tell
   `;

--- a/src/helpers/screencapture.ts
+++ b/src/helpers/screencapture.ts
@@ -3,14 +3,12 @@ import { readFile, unlink } from "node:fs/promises";
 import { promisify } from "node:util";
 import { randomBytes } from "node:crypto";
 import { escapeAppleScriptString } from "./applescript.js";
+import { DEFAULT_MAX_DIMENSION } from "../constants.js";
 
 const execFileAsync = promisify(execFile);
 
 /** Timeout for screencapture and image-processing commands (ms). */
 const COMMAND_TIMEOUT_MS = 10_000;
-
-/** Default maximum dimension for resizing screenshots. */
-const DEFAULT_MAX_DIMENSION = 1024;
 
 /** Prefix for temporary screenshot files. */
 const TMPFILE_PREFIX = "/tmp/mac-use-mcp-";

--- a/src/helpers/screencapture.ts
+++ b/src/helpers/screencapture.ts
@@ -1,11 +1,8 @@
-import { execFile } from "node:child_process";
 import { readFile, unlink } from "node:fs/promises";
-import { promisify } from "node:util";
 import { randomBytes } from "node:crypto";
 import { escapeAppleScriptString } from "./applescript.js";
 import { DEFAULT_MAX_DIMENSION } from "../constants.js";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "./exec.js";
 
 /** Timeout for screencapture and image-processing commands (ms). */
 const COMMAND_TIMEOUT_MS = 10_000;

--- a/src/helpers/screencapture.ts
+++ b/src/helpers/screencapture.ts
@@ -1,11 +1,8 @@
 import { readFile, unlink } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { escapeAppleScriptString } from "./applescript.js";
-import { DEFAULT_MAX_DIMENSION } from "../constants.js";
+import { DEFAULT_MAX_DIMENSION, SCREENCAPTURE_TIMEOUT_MS } from "../constants.js";
 import { execFileAsync } from "./exec.js";
-
-/** Timeout for screencapture and image-processing commands (ms). */
-const COMMAND_TIMEOUT_MS = 10_000;
 
 /** Prefix for temporary screenshot files. */
 const TMPFILE_PREFIX = "/tmp/mac-use-mcp-";
@@ -88,7 +85,7 @@ async function getWindowId(windowTitle: string): Promise<string> {
   `;
 
   const { stdout } = await execFileAsync("osascript", ["-e", script], {
-    timeout: COMMAND_TIMEOUT_MS,
+    timeout: SCREENCAPTURE_TIMEOUT_MS,
   });
   return stdout.trim();
 }
@@ -105,7 +102,7 @@ async function getImageDimensions(
   const { stdout } = await execFileAsync(
     "sips",
     ["-g", "pixelWidth", "-g", "pixelHeight", filePath],
-    { timeout: COMMAND_TIMEOUT_MS },
+    { timeout: SCREENCAPTURE_TIMEOUT_MS },
   );
 
   const widthMatch = stdout.match(/pixelWidth:\s*(\d+)/);
@@ -192,7 +189,7 @@ export async function captureScreen(
 
     // Capture the screenshot
     await execFileAsync("screencapture", args, {
-      timeout: COMMAND_TIMEOUT_MS,
+      timeout: SCREENCAPTURE_TIMEOUT_MS,
     });
 
     // Get original dimensions (physical pixels) before resizing
@@ -204,7 +201,7 @@ export async function captureScreen(
 
     // Resize to fit within maxDimension
     await execFileAsync("sips", ["-Z", String(maxDimension), tmpPath], {
-      timeout: COMMAND_TIMEOUT_MS,
+      timeout: SCREENCAPTURE_TIMEOUT_MS,
     });
 
     // Get final dimensions after resizing

--- a/src/helpers/screencapture.ts
+++ b/src/helpers/screencapture.ts
@@ -1,8 +1,9 @@
 import { readFile, unlink } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
-import { escapeAppleScriptString } from "./applescript.js";
 import { DEFAULT_MAX_DIMENSION, SCREENCAPTURE_TIMEOUT_MS } from "../constants.js";
 import { execFileAsync } from "./exec.js";
+import { runInputHelper } from "./input-helper.js";
+import { ListWindowsResponseSchema } from "../tools/window.js";
 
 /** Prefix for temporary screenshot files. */
 const TMPFILE_PREFIX = "/tmp/mac-use-mcp-";
@@ -54,40 +55,29 @@ export interface ScreenshotResult {
 }
 
 /**
- * Resolve the macOS window ID for a given window title using AppleScript.
+ * Resolve the macOS CGWindowID for a given window title using the Swift helper.
  *
- * Searches all running applications for a window whose name contains
- * the specified title (case-insensitive).
+ * Searches all windows for one whose title contains the specified text
+ * (case-insensitive). Returns the real CGWindowID compatible with screencapture -l.
  *
  * @param windowTitle - Partial or full window title to search for.
  * @returns The numeric CGWindowID as a string.
  * @throws If no matching window is found.
  */
 async function getWindowId(windowTitle: string): Promise<string> {
-  const safeTitle = escapeAppleScriptString(windowTitle);
-  const script = `
-    tell application "System Events"
-      set matchedId to ""
-      repeat with proc in (every process whose background only is false)
-        try
-          repeat with w in (every window of proc)
-            if name of w contains "${safeTitle}" then
-              set matchedId to id of w
-              exit repeat
-            end if
-          end repeat
-        end try
-        if matchedId is not "" then exit repeat
-      end repeat
-      if matchedId is "" then error "No window found matching: ${safeTitle}"
-      return matchedId
-    end tell
-  `;
+  const response = await runInputHelper("list_windows", {});
+  const result = ListWindowsResponseSchema.parse(response);
 
-  const { stdout } = await execFileAsync("osascript", ["-e", script], {
-    timeout: SCREENCAPTURE_TIMEOUT_MS,
-  });
-  return stdout.trim();
+  const titleLower = windowTitle.toLowerCase();
+  const match = result.windows.find(
+    w => w.title.toLowerCase().includes(titleLower),
+  );
+
+  if (!match) {
+    throw new Error(`No window found matching: ${windowTitle}`);
+  }
+
+  return String(match.id);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   ListToolsRequestSchema,
   type CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
+import { ZodError } from "zod";
 
 import {
   utilityToolDefinitions,
@@ -105,6 +106,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     return await handler((args ?? {}) as Record<string, unknown>);
   } catch (error: unknown) {
+    if (error instanceof ZodError) {
+      const flat = error.flatten();
+      const fieldErrors = Object.entries(flat.fieldErrors)
+        .map(([field, msgs]) => `  ${field}: ${(msgs ?? []).join(", ")}`)
+        .join("\n");
+      const formErrors = flat.formErrors.length > 0
+        ? flat.formErrors.join(", ")
+        : "";
+      const detail = [formErrors, fieldErrors].filter(Boolean).join("\n");
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Validation error:\n${detail}`,
+          },
+        ],
+        isError: true,
+      };
+    }
     return {
       content: [
         {

--- a/src/tools/clipboard.ts
+++ b/src/tools/clipboard.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { zodToToolInputSchema } from "../helpers/schema.js";
 import { clipboardRead, clipboardWrite } from "../helpers/clipboard.js";
 
 // -- Schemas -----------------------------------------------------------------
+
+const ClipboardReadInputSchema = z.object({});
 
 const ClipboardWriteInputSchema = z.object({
   text: z.string().describe("Text to write to the clipboard."),
@@ -15,10 +18,7 @@ export const clipboardToolDefinitions: Tool[] = [
     name: "clipboard_read",
     description:
       "Read the current contents of the macOS clipboard as plain text.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {},
-    },
+    inputSchema: zodToToolInputSchema(ClipboardReadInputSchema),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -27,16 +27,7 @@ export const clipboardToolDefinitions: Tool[] = [
   {
     name: "clipboard_write",
     description: "Write text to the macOS clipboard.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        text: {
-          type: "string",
-          description: "Text to write to the clipboard.",
-        },
-      },
-      required: ["text"],
-    },
+    inputSchema: zodToToolInputSchema(ClipboardWriteInputSchema),
     annotations: {
       readOnlyHint: false,
       destructiveHint: false,

--- a/src/tools/clipboard.ts
+++ b/src/tools/clipboard.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
 import { clipboardRead, clipboardWrite } from "../helpers/clipboard.js";
+import { enqueue } from "../queue.js";
 
 // -- Schemas -----------------------------------------------------------------
 
@@ -73,11 +74,11 @@ async function handleClipboardWrite(
 
 // -- Dispatcher --------------------------------------------------------------
 
-/** Map of clipboard tool names to their handler functions. */
+/** Map of clipboard tool names to their handler functions (queued). */
 export const clipboardToolHandlers: Record<
   string,
   (args: Record<string, unknown>) => Promise<CallToolResult>
 > = {
-  clipboard_read: () => handleClipboardRead(),
-  clipboard_write: handleClipboardWrite,
+  clipboard_read: () => enqueue(() => handleClipboardRead()),
+  clipboard_write: (args) => enqueue(() => handleClipboardWrite(args)),
 };

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { zodToToolInputSchema } from "../helpers/schema.js";
 import { runInputHelper } from "../helpers/input-helper.js";
 import { enqueue } from "../queue.js";
 import { KEY_CODES, MODIFIER_FLAGS } from "../constants.js";
@@ -75,38 +76,13 @@ export const keyboardToolDefinitions: Tool[] = [
     name: "type_text",
     description:
       "Type text at the current cursor position using CGEvent key synthesis. Supports full Unicode including CJK characters and emoji. If secure input is active (e.g. password fields), returns a note suggesting clipboard_write + press_key(\"cmd+v\") as an alternative.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        text: {
-          type: "string",
-          description:
-            "Text to type. Supports full Unicode including CJK and emoji.",
-        },
-        delay_ms: {
-          type: "number",
-          description:
-            "Delay between keystrokes in milliseconds (default 0).",
-        },
-      },
-      required: ["text"],
-    },
+    inputSchema: zodToToolInputSchema(TypeTextInputSchema),
   },
   {
     name: "press_key",
     description:
       'Simulate a key press with optional modifiers using CGEvent. Accepts a key combo string like "cmd+c", "ctrl+shift+F5", or "Return". Modifiers: cmd, ctrl, shift, opt/alt.',
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        key: {
-          type: "string",
-          description:
-            'Key combo string. Examples: "Return", "cmd+c", "ctrl+shift+F5", "alt+Tab".',
-        },
-      },
-      required: ["key"],
-    },
+    inputSchema: zodToToolInputSchema(PressKeyInputSchema),
   },
 ];
 

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -3,12 +3,12 @@ import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
 import { runInputHelper } from "../helpers/input-helper.js";
 import { enqueue } from "../queue.js";
-import { KEY_CODES, MODIFIER_FLAGS } from "../constants.js";
+import { KEY_CODES } from "../constants.js";
 
 // -- Constants ---------------------------------------------------------------
 
-/** Modifier name aliases mapped to canonical MODIFIER_FLAGS keys. */
-const MODIFIER_ALIASES: Record<string, keyof typeof MODIFIER_FLAGS> = {
+/** Modifier name aliases mapped to canonical names. */
+const MODIFIER_ALIASES: Record<string, string> = {
   cmd: "command",
   command: "command",
   ctrl: "control",
@@ -159,8 +159,8 @@ async function handlePressKey(
     };
   }
 
-  // Build combined modifier flags
-  let modifiers = 0;
+  // Build modifier name array for the Swift helper
+  const modifiers: string[] = [];
   for (const mod of modifierNames) {
     const canonical = MODIFIER_ALIASES[mod.toLowerCase()];
     if (canonical === undefined) {
@@ -174,7 +174,7 @@ async function handlePressKey(
         ],
       };
     }
-    modifiers |= MODIFIER_FLAGS[canonical];
+    modifiers.push(canonical);
   }
 
   await runInputHelper("key", { code, modifiers });

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -45,12 +45,16 @@ const KEY_NAME_EXAMPLES = [
 
 // -- Schemas -----------------------------------------------------------------
 
+/** Maximum delay between keystrokes in milliseconds (1 second). */
+const TYPE_DELAY_MAX_MS = 1_000;
+
 const TypeTextInputSchema = z.object({
   text: z.string().min(1).describe("Text to type. Supports full Unicode including CJK and emoji."),
   delay_ms: z
     .number()
     .int()
     .min(0)
+    .max(TYPE_DELAY_MAX_MS)
     .optional()
     .describe("Delay between keystrokes in milliseconds (default 0)."),
 });

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
-import { runInputHelper } from "../helpers/input-helper.js";
+import { clipboardRead, clipboardWrite } from "../helpers/clipboard.js";
+import { execFileAsync } from "../helpers/exec.js";
 import { enqueue } from "../queue.js";
-import { KEY_CODES } from "../constants.js";
+import { KEY_CODES, APPLESCRIPT_TIMEOUT_MS } from "../constants.js";
 
 // -- Constants ---------------------------------------------------------------
 
@@ -44,20 +45,13 @@ const KEY_NAME_EXAMPLES = [
   "PageDown",
 ];
 
-// -- Schemas -----------------------------------------------------------------
+/** Delay after paste before restoring clipboard (ms). */
+const PASTE_SETTLE_MS = 50;
 
-/** Maximum delay between keystrokes in milliseconds (1 second). */
-const TYPE_DELAY_MAX_MS = 1_000;
+// -- Schemas -----------------------------------------------------------------
 
 const TypeTextInputSchema = z.object({
   text: z.string().min(1).describe("Text to type. Supports full Unicode including CJK and emoji."),
-  delay_ms: z
-    .number()
-    .int()
-    .min(0)
-    .max(TYPE_DELAY_MAX_MS)
-    .optional()
-    .describe("Delay between keystrokes in milliseconds (default 0)."),
 });
 
 const PressKeyInputSchema = z.object({
@@ -75,52 +69,57 @@ export const keyboardToolDefinitions: Tool[] = [
   {
     name: "type_text",
     description:
-      "Type text at the current cursor position using CGEvent key synthesis. Supports full Unicode including CJK characters and emoji. If secure input is active (e.g. password fields), returns a note suggesting clipboard_write + press_key(\"cmd+v\") as an alternative.",
+      "Type text at the current cursor position using clipboard paste. Supports full Unicode including CJK characters and emoji. If secure input is active (e.g. password fields), returns a note suggesting clipboard_write + press_key(\"cmd+v\") as an alternative.",
     inputSchema: zodToToolInputSchema(TypeTextInputSchema),
   },
   {
     name: "press_key",
     description:
-      'Simulate a key press with optional modifiers using CGEvent. Accepts a key combo string like "cmd+c", "ctrl+shift+F5", or "Return". Modifiers: cmd, ctrl, shift, opt/alt.',
+      'Simulate a key press with optional modifiers. Accepts a key combo string like "cmd+c", "ctrl+shift+F5", or "Return". Modifiers: cmd, ctrl, shift, opt/alt.',
     inputSchema: zodToToolInputSchema(PressKeyInputSchema),
   },
 ];
 
 // -- Handlers ----------------------------------------------------------------
 
-/** Handle type_text tool call. */
+/**
+ * Handle type_text tool call.
+ *
+ * Uses clipboard paste (save → write → Cmd+V → restore) instead of CGEvent
+ * key synthesis, which is silently blocked on macOS 26+.
+ */
 async function handleTypeText(
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
   const parsed = TypeTextInputSchema.parse(args);
 
-  // Check if secure input is active before typing
-  const secureStatus = await runInputHelper("secure", {});
-  const secureActive = secureStatus.secure === true;
-
-  if (secureActive) {
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: JSON.stringify(
-            {
-              success: false,
-              secureInputActive: true,
-              note: "Secure input is active (e.g. a password field is focused). CGEvent-based typing is blocked. Use clipboard_write to place text on the clipboard, then press_key(\"cmd+v\") to paste instead.",
-            },
-            null,
-            2,
-          ),
-        },
-      ],
-    };
+  // Save current clipboard contents (best-effort)
+  let oldClipboard = "";
+  try {
+    oldClipboard = await clipboardRead();
+  } catch {
+    // Clipboard may be empty or contain non-text data
   }
 
-  await runInputHelper("type", {
-    text: parsed.text,
-    delay: parsed.delay_ms ?? 0,
-  });
+  // Write target text to clipboard
+  await clipboardWrite(parsed.text);
+
+  // Paste via AppleScript Cmd+V
+  await execFileAsync(
+    "osascript",
+    ["-e", 'tell application "System Events" to key code 9 using command down'],
+    { timeout: APPLESCRIPT_TIMEOUT_MS },
+  );
+
+  // Brief delay for paste to settle before restoring clipboard
+  await new Promise((resolve) => setTimeout(resolve, PASTE_SETTLE_MS));
+
+  // Restore previous clipboard contents (best-effort)
+  try {
+    await clipboardWrite(oldClipboard);
+  } catch {
+    // Best-effort restore
+  }
 
   return {
     content: [
@@ -135,7 +134,12 @@ async function handleTypeText(
   };
 }
 
-/** Handle press_key tool call. */
+/**
+ * Handle press_key tool call.
+ *
+ * Uses AppleScript `key code` via System Events instead of CGEvent,
+ * which is silently blocked for keyboard events on macOS 26+.
+ */
 async function handlePressKey(
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
@@ -159,8 +163,8 @@ async function handlePressKey(
     };
   }
 
-  // Build modifier name array for the Swift helper
-  const modifiers: string[] = [];
+  // Build AppleScript modifier clause
+  const asModifiers: string[] = [];
   for (const mod of modifierNames) {
     const canonical = MODIFIER_ALIASES[mod.toLowerCase()];
     if (canonical === undefined) {
@@ -174,10 +178,18 @@ async function handlePressKey(
         ],
       };
     }
-    modifiers.push(canonical);
+    asModifiers.push(`${canonical} down`);
   }
 
-  await runInputHelper("key", { code, modifiers });
+  // Build and execute AppleScript
+  const script =
+    asModifiers.length > 0
+      ? `tell application "System Events" to key code ${code} using {${asModifiers.join(", ")}}`
+      : `tell application "System Events" to key code ${code}`;
+
+  await execFileAsync("osascript", ["-e", script], {
+    timeout: APPLESCRIPT_TIMEOUT_MS,
+  });
 
   return {
     content: [

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -17,8 +17,14 @@ const CLICK_MODIFIERS = ["command", "shift", "option", "control"] as const;
 /** Default scroll amount in discrete steps. */
 const SCROLL_DEFAULT_AMOUNT = 3;
 
+/** Maximum scroll amount in discrete steps. */
+const SCROLL_MAX_AMOUNT = 100;
+
 /** Default drag duration in milliseconds. 600ms is the minimum for reliable macOS drag recognition. */
 const DRAG_DEFAULT_DURATION_MS = 600;
+
+/** Maximum drag duration in milliseconds (30 seconds). */
+const DRAG_MAX_DURATION_MS = 30_000;
 
 /** Shared hint appended to all interaction tool descriptions. */
 const SILENT_HINT =
@@ -58,6 +64,7 @@ const ScrollInputSchema = z.object({
     .number()
     .int()
     .positive()
+    .max(SCROLL_MAX_AMOUNT)
     .default(SCROLL_DEFAULT_AMOUNT)
     .describe(`Scroll amount in discrete steps (default: ${SCROLL_DEFAULT_AMOUNT})`),
 });
@@ -71,6 +78,7 @@ const DragInputSchema = z.object({
     .number()
     .int()
     .positive()
+    .max(DRAG_MAX_DURATION_MS)
     .default(DRAG_DEFAULT_DURATION_MS)
     .describe(`Drag duration in milliseconds (default: ${DRAG_DEFAULT_DURATION_MS})`),
 });

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { runInputHelper } from "../helpers/input-helper.js";
+import { zodToToolInputSchema } from "../helpers/schema.js";
 import { enqueue } from "../queue.js";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -90,31 +91,7 @@ export const mouseToolDefinitions: Tool[] = [
     name: "click",
     description:
       `Click at the specified screen coordinates. Supports left/right/middle button, single/double/triple click, and modifier keys. ${SILENT_HINT}`,
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        x: { type: "number", description: "X coordinate (non-negative integer)" },
-        y: { type: "number", description: "Y coordinate (non-negative integer)" },
-        button: {
-          type: "string",
-          enum: [...MOUSE_BUTTONS],
-          description: "Mouse button to click (default: left)",
-          default: "left",
-        },
-        click_count: {
-          type: "number",
-          enum: [1, 2, 3],
-          description: "Number of clicks: 1 (single), 2 (double), or 3 (triple)",
-          default: 1,
-        },
-        modifiers: {
-          type: "array",
-          items: { type: "string", enum: [...CLICK_MODIFIERS] },
-          description: "Modifier keys to hold during click",
-        },
-      },
-      required: ["x", "y"],
-    },
+    inputSchema: zodToToolInputSchema(ClickInputSchema),
     annotations: {
       readOnlyHint: false,
       destructiveHint: true,
@@ -123,14 +100,7 @@ export const mouseToolDefinitions: Tool[] = [
   {
     name: "move_mouse",
     description: `Move the mouse cursor to the specified screen coordinates without clicking. ${SILENT_HINT}`,
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        x: { type: "number", description: "X coordinate (non-negative integer)" },
-        y: { type: "number", description: "Y coordinate (non-negative integer)" },
-      },
-      required: ["x", "y"],
-    },
+    inputSchema: zodToToolInputSchema(MoveMouseInputSchema),
     annotations: {
       readOnlyHint: false,
       destructiveHint: false,
@@ -140,24 +110,7 @@ export const mouseToolDefinitions: Tool[] = [
     name: "scroll",
     description:
       `Scroll at the specified screen coordinates in the given direction. ${SILENT_HINT}`,
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        x: { type: "number", description: "X coordinate (non-negative integer)" },
-        y: { type: "number", description: "Y coordinate (non-negative integer)" },
-        direction: {
-          type: "string",
-          enum: [...SCROLL_DIRECTIONS],
-          description: "Scroll direction",
-        },
-        amount: {
-          type: "number",
-          description: `Scroll amount in discrete steps (default: ${SCROLL_DEFAULT_AMOUNT})`,
-          default: SCROLL_DEFAULT_AMOUNT,
-        },
-      },
-      required: ["x", "y", "direction"],
-    },
+    inputSchema: zodToToolInputSchema(ScrollInputSchema),
     annotations: {
       readOnlyHint: false,
       destructiveHint: false,
@@ -175,21 +128,7 @@ export const mouseToolDefinitions: Tool[] = [
       "",
       SILENT_HINT,
     ].join("\n"),
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        start_x: { type: "number", description: "Start X coordinate (non-negative integer)" },
-        start_y: { type: "number", description: "Start Y coordinate (non-negative integer)" },
-        end_x: { type: "number", description: "End X coordinate (non-negative integer)" },
-        end_y: { type: "number", description: "End Y coordinate (non-negative integer)" },
-        duration_ms: {
-          type: "number",
-          description: `Drag duration in milliseconds (default: ${DRAG_DEFAULT_DURATION_MS})`,
-          default: DRAG_DEFAULT_DURATION_MS,
-        },
-      },
-      required: ["start_x", "start_y", "end_x", "end_y"],
-    },
+    inputSchema: zodToToolInputSchema(DragInputSchema),
     annotations: {
       readOnlyHint: false,
       destructiveHint: true,

--- a/src/tools/screen.ts
+++ b/src/tools/screen.ts
@@ -20,6 +20,24 @@ const GetScreenInfoInputSchema = z.object({});
 
 const GetCursorPositionInputSchema = z.object({});
 
+// -- Response schemas (validate Swift helper output) -------------------------
+
+const DisplayInfoResponseSchema = z.object({
+  displays: z.array(z.object({
+    name: z.string(),
+    width: z.number(),
+    height: z.number(),
+    x: z.number(),
+    y: z.number(),
+    scaleFactor: z.number(),
+  })),
+});
+
+const CursorPositionResponseSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+});
+
 // -- Tool definitions --------------------------------------------------------
 
 export const screenToolDefinitions: Tool[] = [
@@ -49,14 +67,7 @@ export const screenToolDefinitions: Tool[] = [
 /** Handle get_screen_info tool call. */
 async function handleGetScreenInfo(): Promise<CallToolResult> {
   const response = await runInputHelper("display_info", {});
-  const rawDisplays = response.displays as Array<{
-    name: string;
-    width: number;
-    height: number;
-    x: number;
-    y: number;
-    scaleFactor: number;
-  }>;
+  const { displays: rawDisplays } = DisplayInfoResponseSchema.parse(response);
 
   const displays: DisplayInfo[] = rawDisplays.map((d) => ({
     name: d.name,
@@ -83,8 +94,7 @@ async function handleGetScreenInfo(): Promise<CallToolResult> {
 /** Handle get_cursor_position tool call. */
 async function handleGetCursorPosition(): Promise<CallToolResult> {
   const response = await runInputHelper("cursor", {});
-  const x = response.x as number;
-  const y = response.y as number;
+  const { x, y } = CursorPositionResponseSchema.parse(response);
 
   return {
     content: [

--- a/src/tools/screen.ts
+++ b/src/tools/screen.ts
@@ -1,4 +1,6 @@
+import { z } from "zod";
 import { runInputHelper } from "../helpers/input-helper.js";
+import { zodToToolInputSchema } from "../helpers/schema.js";
 import { enqueue } from "../queue.js";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -12,6 +14,12 @@ interface DisplayInfo {
   scaleFactor: number;
 }
 
+// -- Schemas -----------------------------------------------------------------
+
+const GetScreenInfoInputSchema = z.object({});
+
+const GetCursorPositionInputSchema = z.object({});
+
 // -- Tool definitions --------------------------------------------------------
 
 export const screenToolDefinitions: Tool[] = [
@@ -19,10 +27,7 @@ export const screenToolDefinitions: Tool[] = [
     name: "get_screen_info",
     description:
       "Retrieve display configuration: number of displays, per-display resolution, origin, and scale factor.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {},
-    },
+    inputSchema: zodToToolInputSchema(GetScreenInfoInputSchema),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -31,10 +36,7 @@ export const screenToolDefinitions: Tool[] = [
   {
     name: "get_cursor_position",
     description: "Get the current mouse cursor position in screen coordinates.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {},
-    },
+    inputSchema: zodToToolInputSchema(GetCursorPositionInputSchema),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -16,6 +16,14 @@ const MIN_MAX_DIMENSION = 256;
 /** Maximum allowed value for max_dimension. */
 const MAX_MAX_DIMENSION = 4096;
 
+// -- Response schemas (validate Swift helper output) -------------------------
+
+const DisplayScaleResponseSchema = z.object({
+  displays: z.array(z.object({
+    scaleFactor: z.number(),
+  })),
+});
+
 /** Permission setup instructions shown when screenshot capture fails. */
 const PERMISSION_INSTRUCTIONS =
   "Screen Recording permission is required. " +
@@ -124,7 +132,7 @@ async function handleScreenshot(
   try {
     // Get display scale factor for logical dimension computation
     const displayResponse = await runInputHelper("display_info", {});
-    const displays = displayResponse.displays as Array<{ scaleFactor: number }>;
+    const { displays } = DisplayScaleResponseSchema.parse(displayResponse);
     const scaleFactor = displays.length > 0 ? displays[0].scaleFactor : 1;
 
     const result = await captureScreen({

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { captureScreen } from "../helpers/screencapture.js";
 import { runInputHelper } from "../helpers/input-helper.js";
+import { zodToToolInputSchema } from "../helpers/schema.js";
 import { enqueue } from "../queue.js";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -23,53 +24,56 @@ const PERMISSION_INSTRUCTIONS =
 
 // -- Schemas -----------------------------------------------------------------
 
-const ScreenshotInputSchema = z
-  .object({
-    mode: z
-      .enum(["full", "region", "window"])
-      .default("full")
-      .describe('Capture mode: "full" (entire screen), "region" (rectangular area), or "window" (specific window)'),
-    x: z
-      .number()
-      .int()
-      .min(0)
-      .optional()
-      .describe("Left edge x-coordinate in screen pixels (required when mode is region)"),
-    y: z
-      .number()
-      .int()
-      .min(0)
-      .optional()
-      .describe("Top edge y-coordinate in screen pixels (required when mode is region)"),
-    width: z
-      .number()
-      .int()
-      .min(1)
-      .optional()
-      .describe("Region width in screen pixels (required when mode is region)"),
-    height: z
-      .number()
-      .int()
-      .min(1)
-      .optional()
-      .describe("Region height in screen pixels (required when mode is region)"),
-    window_title: z
-      .string()
-      .min(1)
-      .optional()
-      .describe("Window title to capture (required when mode is window)"),
-    max_dimension: z
-      .number()
-      .int()
-      .min(MIN_MAX_DIMENSION)
-      .max(MAX_MAX_DIMENSION)
-      .default(DEFAULT_MAX_DIMENSION)
-      .describe(`Maximum width or height of the returned image (${MIN_MAX_DIMENSION}–${MAX_MAX_DIMENSION}, default ${DEFAULT_MAX_DIMENSION})`),
-    format: z
-      .enum(["png", "jpeg"])
-      .default("png")
-      .describe('Output image format: "png" (default) or "jpeg"'),
-  })
+/** Base object schema for screenshot input (used for JSON Schema generation). */
+const ScreenshotBaseSchema = z.object({
+  mode: z
+    .enum(["full", "region", "window"])
+    .default("full")
+    .describe('Capture mode: "full" (entire screen), "region" (rectangular area), or "window" (specific window)'),
+  x: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Left edge x-coordinate in screen pixels (required when mode is region)"),
+  y: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Top edge y-coordinate in screen pixels (required when mode is region)"),
+  width: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe("Region width in screen pixels (required when mode is region)"),
+  height: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe("Region height in screen pixels (required when mode is region)"),
+  window_title: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Window title to capture (required when mode is window)"),
+  max_dimension: z
+    .number()
+    .int()
+    .min(MIN_MAX_DIMENSION)
+    .max(MAX_MAX_DIMENSION)
+    .default(DEFAULT_MAX_DIMENSION)
+    .describe(`Maximum width or height of the returned image (${MIN_MAX_DIMENSION}–${MAX_MAX_DIMENSION}, default ${DEFAULT_MAX_DIMENSION})`),
+  format: z
+    .enum(["png", "jpeg"])
+    .default("png")
+    .describe('Output image format: "png" (default) or "jpeg"'),
+});
+
+/** Full runtime validation schema with cross-field refinements. */
+const ScreenshotInputSchema = ScreenshotBaseSchema
   .refine(
     (data) => {
       if (data.mode === "region") {
@@ -101,48 +105,7 @@ export const screenshotToolDefinitions: Tool[] = [
     name: "screenshot",
     description:
       "Capture a screenshot of the macOS screen. Supports full screen, a rectangular region, or a specific window by title. Returns a base64-encoded image with dimension metadata. Do not narrate visual observations or coordinate calculations. Brief task progress updates are acceptable.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        mode: {
-          type: "string",
-          enum: ["full", "region", "window"],
-          description: 'Capture mode: "full" (entire screen), "region" (rectangular area), or "window" (specific window)',
-          default: "full",
-        },
-        x: {
-          type: "number",
-          description: "Left edge x-coordinate in screen pixels (required when mode is region)",
-        },
-        y: {
-          type: "number",
-          description: "Top edge y-coordinate in screen pixels (required when mode is region)",
-        },
-        width: {
-          type: "number",
-          description: "Region width in screen pixels (required when mode is region)",
-        },
-        height: {
-          type: "number",
-          description: "Region height in screen pixels (required when mode is region)",
-        },
-        window_title: {
-          type: "string",
-          description: "Window title to capture (required when mode is window)",
-        },
-        max_dimension: {
-          type: "number",
-          description: `Maximum width or height of the returned image (${MIN_MAX_DIMENSION}–${MAX_MAX_DIMENSION}, default ${DEFAULT_MAX_DIMENSION})`,
-          default: DEFAULT_MAX_DIMENSION,
-        },
-        format: {
-          type: "string",
-          enum: ["png", "jpeg"],
-          description: 'Output image format: "png" (default) or "jpeg"',
-          default: "png",
-        },
-      },
-    },
+    inputSchema: zodToToolInputSchema(ScreenshotBaseSchema),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -2,13 +2,11 @@ import { z } from "zod";
 import { captureScreen } from "../helpers/screencapture.js";
 import { runInputHelper } from "../helpers/input-helper.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
+import { DEFAULT_MAX_DIMENSION } from "../constants.js";
 import { enqueue } from "../queue.js";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 // -- Constants ---------------------------------------------------------------
-
-/** Default maximum dimension for resizing screenshots. */
-const DEFAULT_MAX_DIMENSION = 1024;
 
 /** Minimum allowed value for max_dimension. */
 const MIN_MAX_DIMENSION = 256;

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -1,11 +1,8 @@
-import { execFile } from "node:child_process";
 import { stat, unlink } from "node:fs/promises";
-import { promisify } from "node:util";
 import { z } from "zod";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
-
-const execFileAsync = promisify(execFile);
+import { execFileAsync } from "../helpers/exec.js";
 
 // -- Constants ---------------------------------------------------------------
 

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
 import { execFileAsync } from "../helpers/exec.js";
+import { PERMISSION_CHECK_TIMEOUT_MS } from "../constants.js";
 
 // -- Constants ---------------------------------------------------------------
 
@@ -74,7 +75,7 @@ export const utilityToolDefinitions: Tool[] = [
 async function testAccessibility(): Promise<boolean> {
   try {
     await execFileAsync("osascript", ["-e", ACCESSIBILITY_TEST_SCRIPT], {
-      timeout: 5_000,
+      timeout: PERMISSION_CHECK_TIMEOUT_MS,
     });
     return true;
   } catch {
@@ -91,7 +92,7 @@ async function testScreenRecording(): Promise<boolean> {
     await execFileAsync(
       "screencapture",
       ["-x", SCREEN_RECORDING_TEST_PATH],
-      { timeout: 5_000 },
+      { timeout: PERMISSION_CHECK_TIMEOUT_MS },
     );
 
     const info = await stat(SCREEN_RECORDING_TEST_PATH);

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -3,6 +3,7 @@ import { stat, unlink } from "node:fs/promises";
 import { promisify } from "node:util";
 import { z } from "zod";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { zodToToolInputSchema } from "../helpers/schema.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -30,6 +31,8 @@ const SCREEN_RECORDING_INSTRUCTIONS =
 
 // -- Schemas -----------------------------------------------------------------
 
+const CheckPermissionsInputSchema = z.object({});
+
 const WaitInputSchema = z.object({
   duration_ms: z
     .number()
@@ -47,10 +50,7 @@ export const utilityToolDefinitions: Tool[] = [
     name: "check_permissions",
     description:
       "Check whether macOS Accessibility and Screen Recording permissions are granted. Returns status for each permission and instructions for any that are missing.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {},
-    },
+    inputSchema: zodToToolInputSchema(CheckPermissionsInputSchema),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -60,16 +60,7 @@ export const utilityToolDefinitions: Tool[] = [
     name: "wait",
     description:
       "Pause execution for a specified duration. Useful for waiting between UI operations.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        duration_ms: {
-          type: "number",
-          description: "Duration to wait in milliseconds (0–10000, default 500)",
-          default: WAIT_DEFAULT_MS,
-        },
-      },
-    },
+    inputSchema: zodToToolInputSchema(WaitInputSchema),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -177,10 +177,16 @@ function parseWindowRecords(raw: string): WindowInfo[] {
 }
 
 /**
- * Detect whether a name looks like a bundle identifier (contains dots).
+ * Reverse-DNS pattern: at least 3 dot-separated segments, each starting with
+ * a letter and containing only alphanumerics or hyphens (e.g. "com.apple.Safari").
+ */
+const BUNDLE_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9-]*(\.[a-zA-Z][a-zA-Z0-9-]*){2,}$/;
+
+/**
+ * Detect whether a name looks like a bundle identifier (reverse-DNS format).
  */
 function isBundleId(name: string): boolean {
-  return name.includes(".");
+  return BUNDLE_ID_PATTERN.test(name);
 }
 
 // -- Handlers ----------------------------------------------------------------

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -282,27 +282,7 @@ async function handleOpenApplication(
       timeout: OPEN_COMMAND_TIMEOUT_MS,
     });
   } catch (error: unknown) {
-    // If bundle ID failed, the error is final
-    if (flag === "-b") {
-      const msg =
-        error instanceof Error ? error.message : String(error);
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({
-              success: false,
-              error: `Failed to open application "${name}": ${msg}`,
-            }),
-          },
-        ],
-        isError: true,
-      };
-    }
-
-    // For app name, propagate the error as-is
-    const msg =
-      error instanceof Error ? error.message : String(error);
+    const msg = error instanceof Error ? error.message : String(error);
     return {
       content: [
         {

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { z } from "zod";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { runAppleScript } from "../helpers/applescript.js";
+import { runAppleScript, escapeAppleScriptString } from "../helpers/applescript.js";
 import { enqueue } from "../queue.js";
 
 const execFileAsync = promisify(execFile);
@@ -137,13 +137,14 @@ function buildListWindowsScript(app?: string): string {
   const rd = RECORD_DELIMITER;
 
   if (app) {
+    const safeApp = escapeAppleScriptString(app);
     return `
 tell application "System Events"
-  if not (exists process "${app}") then
+  if not (exists process "${safeApp}") then
     return "NOT_RUNNING"
   end if
   set output to ""
-  tell process "${app}"
+  tell process "${safeApp}"
     set winList to every window
     repeat with w in winList
       set wName to name of w
@@ -151,7 +152,7 @@ tell application "System Events"
       set wPos to position of w
       set wSize to size of w
       set wMin to value of attribute "AXMinimized" of w
-      set output to output & "${app}" & "${fd}" & wName & "${fd}" & wId & "${fd}" & (item 1 of wPos) & "${fd}" & (item 2 of wPos) & "${fd}" & (item 1 of wSize) & "${fd}" & (item 2 of wSize) & "${fd}" & wMin & "${rd}"
+      set output to output & "${safeApp}" & "${fd}" & wName & "${fd}" & wId & "${fd}" & (item 1 of wPos) & "${fd}" & (item 2 of wPos) & "${fd}" & (item 1 of wSize) & "${fd}" & (item 2 of wSize) & "${fd}" & wMin & "${rd}"
     end repeat
   end tell
   return output
@@ -260,21 +261,23 @@ async function handleFocusWindow(
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
   const parsed = FocusWindowInputSchema.parse(args);
+  const safeApp = escapeAppleScriptString(parsed.app);
 
   // Activate the application
-  let script = `tell application "${parsed.app}" to activate`;
+  let script = `tell application "${safeApp}" to activate`;
 
   // If a specific window title is requested, raise it via System Events
   if (parsed.title) {
+    const safeTitle = escapeAppleScriptString(parsed.title);
     script += `
 delay 0.3
 tell application "System Events"
-  tell process "${parsed.app}"
+  tell process "${safeApp}"
     set frontmost to true
     try
-      perform action "AXRaise" of (first window whose name is "${parsed.title}")
+      perform action "AXRaise" of (first window whose name is "${safeTitle}")
     on error
-      error "Window titled \\"${parsed.title}\\" not found in ${parsed.app}"
+      error "Window titled \\"${safeTitle}\\" not found in ${safeApp}"
     end try
   end tell
 end tell`;

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -3,16 +3,9 @@ import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
 import { execFileAsync } from "../helpers/exec.js";
 import { runAppleScript, escapeAppleScriptString } from "../helpers/applescript.js";
+import { runInputHelper } from "../helpers/input-helper.js";
 import { OPEN_COMMAND_TIMEOUT_MS } from "../constants.js";
 import { enqueue } from "../queue.js";
-
-// -- Constants ---------------------------------------------------------------
-
-/** Delimiter used to separate fields in AppleScript output. */
-const FIELD_DELIMITER = "|||";
-
-/** Delimiter used to separate window records in AppleScript output. */
-const RECORD_DELIMITER = "<<<>>>";
 
 // -- Schemas -----------------------------------------------------------------
 
@@ -35,6 +28,21 @@ const OpenApplicationInputSchema = z.object({
   name: z
     .string()
     .describe("Application name (e.g. \"Safari\") or bundle identifier (e.g. \"com.apple.Safari\")."),
+});
+
+/** Schema for validating the Swift helper list_windows response. */
+export const ListWindowsResponseSchema = z.object({
+  success: z.boolean(),
+  windows: z.array(z.object({
+    app: z.string(),
+    title: z.string(),
+    id: z.number(),
+    x: z.number(),
+    y: z.number(),
+    width: z.number(),
+    height: z.number(),
+    minimized: z.boolean(),
+  })),
 });
 
 // -- Types -------------------------------------------------------------------
@@ -87,96 +95,6 @@ export const windowToolDefinitions: Tool[] = [
 // -- Helpers -----------------------------------------------------------------
 
 /**
- * Build the AppleScript that queries window information from System Events.
- *
- * When `app` is provided, only that process is queried. Otherwise all
- * processes with visible windows are enumerated.
- *
- * Each window is emitted as a delimited record to make parsing robust
- * against window titles that contain special characters.
- */
-function buildListWindowsScript(app?: string): string {
-  const fd = FIELD_DELIMITER;
-  const rd = RECORD_DELIMITER;
-
-  if (app) {
-    const safeApp = escapeAppleScriptString(app);
-    return `
-tell application "System Events"
-  if not (exists process "${safeApp}") then
-    return "NOT_RUNNING"
-  end if
-  set output to ""
-  tell process "${safeApp}"
-    set winList to every window
-    repeat with w in winList
-      set wName to name of w
-      set wId to id of w
-      set wPos to position of w
-      set wSize to size of w
-      set wMin to value of attribute "AXMinimized" of w
-      set output to output & "${safeApp}" & "${fd}" & wName & "${fd}" & wId & "${fd}" & (item 1 of wPos) & "${fd}" & (item 2 of wPos) & "${fd}" & (item 1 of wSize) & "${fd}" & (item 2 of wSize) & "${fd}" & wMin & "${rd}"
-    end repeat
-  end tell
-  return output
-end tell`;
-  }
-
-  return `
-tell application "System Events"
-  set output to ""
-  set procList to every process whose background only is false
-  repeat with proc in procList
-    set procName to name of proc
-    try
-      set winList to every window of proc
-      repeat with w in winList
-        set wName to name of w
-        set wId to id of w
-        set wPos to position of w
-        set wSize to size of w
-        set wMin to value of attribute "AXMinimized" of w
-        set output to output & procName & "${fd}" & wName & "${fd}" & wId & "${fd}" & (item 1 of wPos) & "${fd}" & (item 2 of wPos) & "${fd}" & (item 1 of wSize) & "${fd}" & (item 2 of wSize) & "${fd}" & wMin & "${rd}"
-      end repeat
-    end try
-  end repeat
-  return output
-end tell`;
-}
-
-/**
- * Parse the delimited AppleScript output into WindowInfo objects.
- */
-function parseWindowRecords(raw: string): WindowInfo[] {
-  if (!raw || raw === "NOT_RUNNING") return [];
-
-  const records = raw.split(RECORD_DELIMITER).filter((r) => r.length > 0);
-  const windows: WindowInfo[] = [];
-
-  for (const record of records) {
-    const fields = record.split(FIELD_DELIMITER);
-    if (fields.length < 8) continue;
-
-    windows.push({
-      app: fields[0],
-      title: fields[1],
-      id: parseInt(fields[2], 10) || 0,
-      position: {
-        x: parseInt(fields[3], 10) || 0,
-        y: parseInt(fields[4], 10) || 0,
-      },
-      size: {
-        w: parseInt(fields[5], 10) || 0,
-        h: parseInt(fields[6], 10) || 0,
-      },
-      minimized: fields[7].trim().toLowerCase() === "true",
-    });
-  }
-
-  return windows;
-}
-
-/**
  * Reverse-DNS pattern: at least 3 dot-separated segments, each starting with
  * a letter and containing only alphanumerics, hyphens, or underscores
  * (e.g. "com.apple.Safari", "com.apple.driver.Apple_HDA").
@@ -197,24 +115,17 @@ async function handleListWindows(
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
   const parsed = ListWindowsInputSchema.parse(args);
-  const script = buildListWindowsScript(parsed.app);
-  const raw = await runAppleScript(script);
+  const response = await runInputHelper("list_windows", parsed.app ? { app: parsed.app } : {});
+  const result = ListWindowsResponseSchema.parse(response);
 
-  if (raw === "NOT_RUNNING") {
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: JSON.stringify({
-            error: `Application "${parsed.app}" is not running`,
-            windows: [],
-          }),
-        },
-      ],
-    };
-  }
-
-  const windows = parseWindowRecords(raw);
+  const windows: WindowInfo[] = result.windows.map(w => ({
+    app: w.app,
+    title: w.title,
+    id: w.id,
+    position: { x: w.x, y: w.y },
+    size: { w: w.width, h: w.height },
+    minimized: w.minimized,
+  }));
 
   return {
     content: [

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -178,9 +178,10 @@ function parseWindowRecords(raw: string): WindowInfo[] {
 
 /**
  * Reverse-DNS pattern: at least 3 dot-separated segments, each starting with
- * a letter and containing only alphanumerics or hyphens (e.g. "com.apple.Safari").
+ * a letter and containing only alphanumerics, hyphens, or underscores
+ * (e.g. "com.apple.Safari", "com.apple.driver.Apple_HDA").
  */
-const BUNDLE_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9-]*(\.[a-zA-Z][a-zA-Z0-9-]*){2,}$/;
+const BUNDLE_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*){2,}$/;
 
 /**
  * Detect whether a name looks like a bundle identifier (reverse-DNS format).

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -3,12 +3,10 @@ import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
 import { execFileAsync } from "../helpers/exec.js";
 import { runAppleScript, escapeAppleScriptString } from "../helpers/applescript.js";
+import { OPEN_COMMAND_TIMEOUT_MS } from "../constants.js";
 import { enqueue } from "../queue.js";
 
 // -- Constants ---------------------------------------------------------------
-
-/** Timeout for the `open` command (ms). */
-const OPEN_COMMAND_TIMEOUT_MS = 5_000;
 
 /** Delimiter used to separate fields in AppleScript output. */
 const FIELD_DELIMITER = "|||";

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { z } from "zod";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { zodToToolInputSchema } from "../helpers/schema.js";
 import { runAppleScript, escapeAppleScriptString } from "../helpers/applescript.js";
 import { enqueue } from "../queue.js";
 
@@ -60,16 +61,7 @@ export const windowToolDefinitions: Tool[] = [
     name: "list_windows",
     description:
       "List visible windows with their app name, title, ID, position, size, and minimized state. Optionally filter by application name.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        app: {
-          type: "string",
-          description:
-            "Application name to filter by. If omitted, list windows from all applications.",
-        },
-      },
-    },
+    inputSchema: zodToToolInputSchema(ListWindowsInputSchema),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -79,21 +71,7 @@ export const windowToolDefinitions: Tool[] = [
     name: "focus_window",
     description:
       "Activate an application and optionally raise a specific window by title.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        app: {
-          type: "string",
-          description: "Application name to activate.",
-        },
-        title: {
-          type: "string",
-          description:
-            "Window title to raise. If omitted, the frontmost window of the application is activated.",
-        },
-      },
-      required: ["app"],
-    },
+    inputSchema: zodToToolInputSchema(FocusWindowInputSchema),
     annotations: {
       readOnlyHint: false,
       destructiveHint: false,
@@ -103,17 +81,7 @@ export const windowToolDefinitions: Tool[] = [
     name: "open_application",
     description:
       "Launch an application by name or bundle identifier.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        name: {
-          type: "string",
-          description:
-            "Application name (e.g. \"Safari\") or bundle identifier (e.g. \"com.apple.Safari\").",
-        },
-      },
-      required: ["name"],
-    },
+    inputSchema: zodToToolInputSchema(OpenApplicationInputSchema),
     annotations: {
       readOnlyHint: false,
       destructiveHint: false,

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -1,12 +1,9 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { z } from "zod";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
+import { execFileAsync } from "../helpers/exec.js";
 import { runAppleScript, escapeAppleScriptString } from "../helpers/applescript.js";
 import { enqueue } from "../queue.js";
-
-const execFileAsync = promisify(execFile);
 
 // -- Constants ---------------------------------------------------------------
 

--- a/swift/input-helper.swift
+++ b/swift/input-helper.swift
@@ -170,6 +170,67 @@ func handleCursor() {
     ])
 }
 
+// MARK: - Keyboard Helpers
+
+/// Translate a virtual key code to Unicode character(s) using the current keyboard layout.
+///
+/// Returns nil for non-printable keys (Return, Tab, Escape, arrow keys, etc.).
+private func translateKeyCode(_ keyCode: UInt16, modifierFlags: CGEventFlags) -> String? {
+    guard let inputSource = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+          let rawLayoutData = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData) else {
+        return nil
+    }
+
+    let layoutData = unsafeBitCast(rawLayoutData, to: CFData.self)
+    let keyLayoutPtr = unsafeBitCast(
+        CFDataGetBytePtr(layoutData),
+        to: UnsafePointer<UCKeyboardLayout>.self
+    )
+
+    // Convert CGEventFlags to Carbon modifier key state
+    var modifierKeyState: UInt32 = 0
+    let rawFlags = modifierFlags.rawValue
+    if rawFlags & CGEventFlags.maskShift.rawValue != 0 {
+        modifierKeyState |= UInt32(shiftKey >> 8) & 0xFF
+    }
+    if rawFlags & CGEventFlags.maskCommand.rawValue != 0 {
+        modifierKeyState |= UInt32(cmdKey >> 8) & 0xFF
+    }
+    if rawFlags & CGEventFlags.maskAlternate.rawValue != 0 {
+        modifierKeyState |= UInt32(optionKey >> 8) & 0xFF
+    }
+    if rawFlags & CGEventFlags.maskControl.rawValue != 0 {
+        modifierKeyState |= UInt32(controlKey >> 8) & 0xFF
+    }
+
+    var deadKeyState: UInt32 = 0
+    let maxChars = 4
+    var length = 0
+    var chars = [UniChar](repeating: 0, count: maxChars)
+
+    let status = UCKeyTranslate(
+        keyLayoutPtr,
+        keyCode,
+        UInt16(kUCKeyActionDown),
+        modifierKeyState,
+        UInt32(LMGetKbdType()),
+        UInt32(kUCKeyTranslateNoDeadKeysBit),
+        &deadKeyState,
+        maxChars,
+        &length,
+        &chars
+    )
+
+    guard status == noErr, length > 0 else { return nil }
+
+    let result = String(utf16CodeUnits: chars, count: length)
+    // Skip control characters (Return=\r, Tab=\t, Escape=\u{1b}, etc.)
+    if result.unicodeScalars.allSatisfy({ $0.value < 32 }) {
+        return nil
+    }
+    return result
+}
+
 // MARK: - Keyboard Command Handlers
 
 /// Maximum number of UTF-16 code units per chunk for keyboardSetUnicodeString.
@@ -224,6 +285,8 @@ func handleType(_ args: [String: Any]) {
 /// Handle the "key" command.
 ///
 /// Synthesizes a single key press with optional modifier flags.
+/// Populates Unicode character data via UCKeyTranslate so that apps
+/// relying on character data (e.g. Calculator) receive the correct input.
 ///
 /// Args: {"code":Int, "modifiers":["cmd","shift","ctrl","opt"]}
 ///   - code:      Virtual key code (e.g. 0 = 'a', 36 = Return).
@@ -242,6 +305,13 @@ func handleKey(_ args: [String: Any]) {
 
     applyModifiers(keyDown, modifiers)
     applyModifiers(keyUp, modifiers)
+
+    // Populate Unicode character data for apps that rely on it (e.g. Calculator)
+    if let character = translateKeyCode(UInt16(code), modifierFlags: keyDown.flags) {
+        var utf16 = Array(character.utf16)
+        keyDown.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+        keyUp.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+    }
 
     keyDown.post(tap: .cghidEventTap)
     keyUp.post(tap: .cghidEventTap)

--- a/swift/input-helper.swift
+++ b/swift/input-helper.swift
@@ -417,6 +417,70 @@ func handleDisplayInfo() {
     outputJSON(["success": true, "displays": displays])
 }
 
+// MARK: - Window Enumeration Handler
+
+/// Handle the "list_windows" command.
+///
+/// Uses CGWindowListCopyWindowInfo for robust window enumeration.
+/// Returns real CGWindowIDs that work with screencapture -l.
+///
+/// Args: {"app":"optional filter"}
+/// Returns: {"success":true, "windows":[{app, title, id, x, y, width, height, minimized}]}
+func handleListWindows(_ args: [String: Any]) {
+    let filterApp = args["app"] as? String
+
+    guard let windowList = CGWindowListCopyWindowInfo(
+        [.optionAll, .excludeDesktopElements],
+        kCGNullWindowID
+    ) as? [[String: Any]] else {
+        outputJSON(["success": true, "windows": []])
+        return
+    }
+
+    var windows: [[String: Any]] = []
+
+    for window in windowList {
+        guard let ownerName = window[kCGWindowOwnerName as String] as? String,
+              let windowNumber = window[kCGWindowNumber as String] as? Int,
+              let bounds = window[kCGWindowBounds as String] as? [String: Any] else {
+            continue
+        }
+
+        // Only include normal windows (layer 0)
+        let layer = window[kCGWindowLayer as String] as? Int ?? -1
+        if layer != 0 { continue }
+
+        guard let x = bounds["X"] as? Double,
+              let y = bounds["Y"] as? Double,
+              let width = bounds["Width"] as? Double,
+              let height = bounds["Height"] as? Double else {
+            continue
+        }
+
+        // Skip tiny/invisible windows
+        if width < 1 || height < 1 { continue }
+
+        // Apply app filter
+        if let filter = filterApp, ownerName != filter { continue }
+
+        let title = window[kCGWindowName as String] as? String ?? ""
+        let isOnscreen = window[kCGWindowIsOnscreen as String] as? Bool ?? false
+
+        windows.append([
+            "app": ownerName,
+            "title": title,
+            "id": windowNumber,
+            "x": Int(x),
+            "y": Int(y),
+            "width": Int(width),
+            "height": Int(height),
+            "minimized": !isOnscreen,
+        ])
+    }
+
+    outputJSON(["success": true, "windows": windows])
+}
+
 // MARK: - Main Entry Point
 
 let arguments = CommandLine.arguments
@@ -455,6 +519,8 @@ case "secure":
     handleSecure()
 case "display_info":
     handleDisplayInfo()
+case "list_windows":
+    handleListWindows(args)
 default:
     fail("unknown command: \(command)")
 }

--- a/swift/input-helper.swift
+++ b/swift/input-helper.swift
@@ -26,11 +26,16 @@ func fail(_ message: String) -> Never {
 // MARK: - Modifier Helpers
 
 /// Map of human-readable modifier names to CGEventFlags raw values.
+/// Accepts both short ("cmd") and full ("command") names for robustness.
 private let modifierFlagMap: [String: UInt64] = [
-    "cmd":   0x100000,
-    "shift": 0x020000,
-    "ctrl":  0x040000,
-    "opt":   0x080000,
+    "cmd":     0x100000,
+    "command": 0x100000,
+    "shift":   0x020000,
+    "ctrl":    0x040000,
+    "control": 0x040000,
+    "opt":     0x080000,
+    "option":  0x080000,
+    "alt":     0x080000,
 ]
 
 /// Apply string-based modifier names to a CGEvent.

--- a/swift/input-helper.swift
+++ b/swift/input-helper.swift
@@ -385,10 +385,13 @@ func handleSecure() {
 ///
 /// Args: {} (none required)
 /// Returns: {"success":true, "displays":[{name, width, height, x, y, scaleFactor}]}
+/// Maximum number of displays to query from CGGetActiveDisplayList.
+private let maxDisplayCount: UInt32 = 32
+
 func handleDisplayInfo() {
-    var displayIDs = [CGDirectDisplayID](repeating: 0, count: 32)
+    var displayIDs = [CGDirectDisplayID](repeating: 0, count: Int(maxDisplayCount))
     var displayCount: UInt32 = 0
-    CGGetActiveDisplayList(32, &displayIDs, &displayCount)
+    CGGetActiveDisplayList(maxDisplayCount, &displayIDs, &displayCount)
 
     var displays: [[String: Any]] = []
     for i in 0..<Int(displayCount) {


### PR DESCRIPTION
## Summary

- **Security**: escape AppleScript string interpolation to prevent injection; shared `escapeAppleScriptString` helper
- **Input validation**: Zod schemas for Swift helper responses and tool inputs; max bounds on numeric parameters; improved bundle-ID regex
- **Code quality**: deduplicate `execFileAsync` and `DEFAULT_MAX_DIMENSION` into shared modules; unify timeout constants with `<CONTEXT>_TIMEOUT_MS` naming; derive JSON Schema from Zod via `zod-to-json-schema`; format ZodError for readable MCP error responses; remove duplicate error branch in `handleOpenApplication`; queue clipboard operations to prevent race conditions
- **Window management**: replace AppleScript-based window enumeration with `CGWindowListCopyWindowInfo` via Swift helper for reliable CGWindowIDs; use CGWindowID for window screenshots
- **Keyboard (macOS 26)**: switch `type_text` to clipboard-paste and `press_key` to AppleScript `key code`; macOS 26 silently drops CGEvent keyboard events while mouse events are unaffected

## Test plan

- [x] Screenshot, click, scroll, drag unchanged — verified on macOS 26
- [x] `type_text` works with English, CJK, and emoji via clipboard paste
- [x] `press_key` works with single keys and modifier combos via AppleScript
- [x] Clipboard restored after `type_text`
- [x] Window list and focus use CGWindowID correctly
- [x] AppleScript injection payloads in window titles are escaped