### PR TITLE
fix(mouse): replace click_count enum with min/max for Gemini compatibility

### DIFF
--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -49,7 +49,10 @@ const ClickInputSchema = z.object({
     .default("left")
     .describe("Mouse button to click (default: left)"),
   click_count: z
-    .union([z.literal(1), z.literal(2), z.literal(3)])
+    .number()
+    .int()
+    .min(1)
+    .max(3)
     .default(1)
     .describe("Number of clicks: 1 (single), 2 (double), or 3 (triple)"),
   modifiers: z


### PR DESCRIPTION
Gemini API rejects `enum` on non-STRING typed properties (HTTP 400). The `click_count` parameter used `z.union([z.literal(1), z.literal(2), z.literal(3)])` which produces `{ "type": "number", "enum": [1, 2, 3] }` in JSON Schema.

Replace with `z.number().int().min(1).max(3)` to emit standard `minimum`/`maximum` constraints instead. Semantically equivalent, compatible with all MCP clients.