### PR TITLE
ci: optimize dependabot config with grouped updates and monthly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,20 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
- Change schedule from weekly to monthly to reduce PR noise
- Group npm minor+patch updates into a single PR; keep major updates as individual PRs for easier triage
- Group all GitHub Actions updates into a single PR
- Set open-pull-requests-limit (5 for npm, 3 for actions)