### PR TITLE
feat: Phase 2 — screenshot upgrade, menu tool, fuzzy matching, accessibility API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-01
+
 ### Added
+- Built-in screenshot via `CGWindowListCreateImage` — single-process capture at logical resolution, replacing the 3-process `screencapture` + `sips` pipeline
+- Universal coordinate mapping formula (`screen = origin + pixel * scale`) in screenshot response, with 1:1 identity mapping by default
+- `click_menu` tool: click menu bar items by path (e.g., `"File > Save As..."`)
+- `get_ui_elements` tool: semantic UI element discovery via macOS Accessibility API with role/title filters and BFS traversal
+- Fuzzy app name matching for `list_windows`, `focus_window`, `open_application`, and `click_menu` (case-insensitive exact/prefix/contains)
+- Window title → ID resolution via `CGWindowListCopyWindowInfo` (replaces AppleScript, eliminates injection surface)
 - Operation guidance to tool descriptions (#3)
+
+### Changed
+- Default `max_dimension` changed from 1024 to 0 (no resize) — image coordinates equal screen coordinates out of the box
+- Screenshot captures at logical pixels (not physical) — eliminates Retina scaling mismatch
+- Swift `input-helper` binary now handles screenshot, window enumeration, and UI element queries natively
+- Build script targets macOS 13.0 explicitly to suppress SDK deprecation warnings
 
 ### Fixed
 - Use logical points instead of physical pixels for coordinates (#1)
@@ -45,5 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI workflow for macOS
 - Open-source community files (contributing guide, code of conduct, security policy)
 
-[Unreleased]: https://github.com/antbotlab/mac-use-mcp/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/antbotlab/mac-use-mcp/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/antbotlab/mac-use-mcp/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/antbotlab/mac-use-mcp/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npx mac-use-mcp
 
 ## Tools
 
-mac-use-mcp exposes 16 tools to any MCP-compatible client:
+mac-use-mcp exposes 18 tools to any MCP-compatible client:
 
 | Tool | Description |
 | --- | --- |
@@ -34,10 +34,14 @@ mac-use-mcp exposes 16 tools to any MCP-compatible client:
 | `list_windows` | List all visible windows with positions |
 | `focus_window` | Bring a window to the front |
 | `open_application` | Launch an application by name |
+| `click_menu` | Click a menu bar item by path (e.g., "File > Save As...") |
+| `get_ui_elements` | Query UI elements via Accessibility API (roles, positions, titles) |
 | `clipboard_read` | Read the system clipboard contents |
 | `clipboard_write` | Write text to the system clipboard |
 | `wait` | Pause for a specified duration |
 | `check_permissions` | Verify Accessibility and Screen Recording access |
+
+App names support fuzzy matching — `"chrome"` resolves to `"Google Chrome"`, `"code"` to `"Code"`, etc.
 
 ## MCP Client Configuration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mac-use-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Zero-dependency macOS desktop automation via MCP",
   "license": "MIT",
   "author": "antbotlab",

--- a/scripts/build-swift.sh
+++ b/scripts/build-swift.sh
@@ -2,6 +2,14 @@
 set -euo pipefail
 
 mkdir -p dist/bin
-swiftc swift/input-helper.swift -o dist/bin/input-helper -O
+
+# Target macOS 13 (Ventura) — the project's minimum supported version.
+# This also suppresses the "obsoleted" error for CGWindowListCreateImage
+# on macOS 15+ SDKs, where the API is deprecated but still functional.
+swiftc swift/input-helper.swift \
+  -o dist/bin/input-helper \
+  -O \
+  -target "$(uname -m)-apple-macos13.0"
+
 chmod +x dist/bin/input-helper
 echo "Swift helper compiled successfully"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -108,8 +108,8 @@ export const MODIFIER_FLAGS = {
   control: 0x040000,
 } as const;
 
-/** Default maximum dimension (width or height) for screenshot resizing. */
-export const DEFAULT_MAX_DIMENSION = 1024;
+/** Default maximum dimension (width or height) for screenshot resizing. 0 = no resize. */
+export const DEFAULT_MAX_DIMENSION = 0;
 
 // -- Timeouts ----------------------------------------------------------------
 

--- a/src/helpers/app-resolver.ts
+++ b/src/helpers/app-resolver.ts
@@ -1,0 +1,91 @@
+import { runAppleScript } from "./applescript.js";
+
+/**
+ * Resolve a user-provided app name to the actual process name.
+ *
+ * Strategy (in order):
+ * 1. Exact match (case-insensitive) against running process names
+ * 2. Prefix match: "Code" matches "Code - Insiders"
+ * 3. Contains match: "chrome" matches "Google Chrome"
+ * 4. No match: return the original string (let macOS handle it)
+ */
+
+// -- Process name cache ------------------------------------------------------
+
+/** Short-lived cache to avoid repeated System Events queries. */
+let cachedProcessNames: string[] | null = null;
+let cacheTimestamp = 0;
+const CACHE_TTL_MS = 2_000;
+
+/**
+ * Retrieve names of all foreground (non-background-only) processes via
+ * System Events. Results are cached for {@link CACHE_TTL_MS} to avoid
+ * redundant AppleScript calls within rapid successive tool invocations.
+ */
+async function getRunningProcessNames(): Promise<string[]> {
+  const now = Date.now();
+  if (cachedProcessNames && now - cacheTimestamp < CACHE_TTL_MS) {
+    return cachedProcessNames;
+  }
+
+  const output = await runAppleScript(
+    'tell application "System Events" to get name of every process whose background only is false',
+  );
+
+  // osascript returns comma-separated: "Finder, Safari, Code"
+  cachedProcessNames = output
+    .split(", ")
+    .map((n) => n.trim())
+    .filter((n) => n.length > 0);
+  cacheTimestamp = now;
+  return cachedProcessNames;
+}
+
+// -- Matching ----------------------------------------------------------------
+
+/**
+ * Find the best matching process name for a query string.
+ *
+ * @returns The matched process name, or `null` if no match is found.
+ */
+function matchProcessName(query: string, names: string[]): string | null {
+  const q = query.toLowerCase();
+
+  // Exact match (case-insensitive)
+  const exact = names.find((n) => n.toLowerCase() === q);
+  if (exact) return exact;
+
+  // Prefix match
+  const prefix = names.find((n) => n.toLowerCase().startsWith(q));
+  if (prefix) return prefix;
+
+  // Contains match
+  const contains = names.find((n) => n.toLowerCase().includes(q));
+  if (contains) return contains;
+
+  return null;
+}
+
+// -- Public API --------------------------------------------------------------
+
+/**
+ * Resolve a user-provided app name to the actual running process name.
+ *
+ * Attempts exact, prefix, and contains matching (all case-insensitive)
+ * against currently running foreground processes. Returns the original
+ * query unchanged when no match is found, allowing macOS to handle it
+ * directly.
+ *
+ * @param query - The app name provided by the user.
+ * @returns The resolved process name, or the original query if unmatched.
+ */
+export async function resolveAppName(query: string): Promise<string> {
+  try {
+    const names = await getRunningProcessNames();
+    return matchProcessName(query, names) ?? query;
+  } catch {
+    // If process enumeration fails, fall back to the original query
+    // so downstream tools can still attempt to use it as-is.
+    return query;
+  }
+}

--- a/src/helpers/input-helper.ts
+++ b/src/helpers/input-helper.ts
@@ -18,7 +18,8 @@ export type InputCommand =
   | "cursor"
   | "secure"
   | "display_info"
-  | "list_windows";
+  | "list_windows"
+  | "screenshot";
 
 /**
  * Execute the Swift input-helper binary with the given command and arguments.

--- a/src/helpers/input-helper.ts
+++ b/src/helpers/input-helper.ts
@@ -19,7 +19,8 @@ export type InputCommand =
   | "secure"
   | "display_info"
   | "list_windows"
-  | "screenshot";
+  | "screenshot"
+  | "get_ui_elements";
 
 /**
  * Execute the Swift input-helper binary with the given command and arguments.

--- a/src/helpers/screencapture.ts
+++ b/src/helpers/screencapture.ts
@@ -33,12 +33,10 @@ export interface CaptureOptions {
   region?: CaptureRegion;
   /** Window title to capture. Required when mode is "window". */
   windowTitle?: string;
-  /** Maximum dimension (width or height) for resizing. Defaults to 1024. */
+  /** Maximum dimension (width or height) for resizing. 0 means no resize. Defaults to 0. */
   maxDimension?: number;
   /** Output image format. Defaults to "png". */
   format?: ImageFormat;
-  /** Display scale factor (e.g. 2 for Retina). Defaults to 1. */
-  displayScaleFactor?: number;
 }
 
 /** Result of a screen capture operation. */
@@ -49,13 +47,127 @@ export interface ScreenshotResult {
   width: number;
   /** Height of the final image in pixels. */
   height: number;
-  /** Description of the scaling applied. */
-  scaleInfo: string;
-  /** Logical screen width in points (physical pixels / scaleFactor). */
-  screenWidth: number;
-  /** Logical screen height in points (physical pixels / scaleFactor). */
-  screenHeight: number;
+  /** Screen coordinate of image pixel (0,0) — X. */
+  originX: number;
+  /** Screen coordinate of image pixel (0,0) — Y. */
+  originY: number;
+  /** Multiply factor: image_x to screen offset. */
+  scaleX: number;
+  /** Multiply factor: image_y to screen offset. */
+  scaleY: number;
 }
+
+/** Schema shape for the Swift input-helper screenshot response. */
+interface SwiftScreenshotResponse {
+  success: boolean;
+  base64: string;
+  width: number;
+  height: number;
+  origin_x: number;
+  origin_y: number;
+  scale_x: number;
+  scale_y: number;
+  error?: string;
+}
+
+/**
+ * Capture a screenshot via the built-in Swift input-helper (primary path).
+ *
+ * Falls back to the legacy screencapture CLI pipeline if the Swift binary
+ * does not support the "screenshot" command (e.g. old binary version).
+ *
+ * @param options - Capture configuration. Defaults to full-screen PNG, no resize.
+ * @returns Screenshot data including base64 content, dimensions, and coordinate mapping.
+ */
+export async function captureScreen(
+  options: CaptureOptions = {},
+): Promise<ScreenshotResult> {
+  const {
+    mode = "full",
+    region,
+    windowTitle,
+    maxDimension = DEFAULT_MAX_DIMENSION,
+    format = "png",
+  } = options;
+
+  try {
+    return await captureViaInputHelper(
+      mode,
+      region,
+      windowTitle,
+      maxDimension,
+      format,
+    );
+  } catch (error: unknown) {
+    // If the error indicates the binary lacks the "screenshot" command,
+    // fall back to the legacy screencapture CLI pipeline
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("unknown command")) {
+      return captureViaScreencaptureCLI(
+        mode,
+        region,
+        windowTitle,
+        maxDimension,
+        format,
+      );
+    }
+    throw error;
+  }
+}
+
+// -- Primary path: Swift input-helper ----------------------------------------
+
+/**
+ * Capture via the Swift input-helper "screenshot" command.
+ *
+ * Uses CGWindowListCreateImage at logical resolution (no .bestResolution),
+ * with built-in resize and PNG/JPEG encoding.
+ */
+async function captureViaInputHelper(
+  mode: CaptureMode,
+  region: CaptureRegion | undefined,
+  windowTitle: string | undefined,
+  maxDimension: number,
+  format: ImageFormat,
+): Promise<ScreenshotResult> {
+  const helperArgs: Record<string, unknown> = {
+    mode,
+    max_dimension: maxDimension,
+    format,
+  };
+
+  if (mode === "region" && region) {
+    helperArgs.x = region.x;
+    helperArgs.y = region.y;
+    helperArgs.w = region.w;
+    helperArgs.h = region.h;
+  }
+
+  if (mode === "window" && windowTitle) {
+    helperArgs.window_title = windowTitle;
+  }
+
+  const response = (await runInputHelper(
+    "screenshot",
+    helperArgs,
+  )) as unknown as SwiftScreenshotResponse;
+
+  if (!response.success) {
+    throw new Error(response.error ?? "Screenshot capture failed");
+  }
+
+  return {
+    base64: response.base64,
+    width: response.width,
+    height: response.height,
+    originX: response.origin_x,
+    originY: response.origin_y,
+    scaleX: response.scale_x,
+    scaleY: response.scale_y,
+  };
+}
+
+// -- Fallback path: screencapture CLI ----------------------------------------
 
 /**
  * Resolve the macOS CGWindowID for a given window title using the Swift helper.
@@ -125,28 +237,19 @@ function makeTmpPath(format: ImageFormat): string {
 }
 
 /**
- * Capture a screenshot of the macOS screen using the native screencapture CLI.
+ * Legacy fallback: capture a screenshot using the macOS screencapture CLI.
  *
- * Supports full screen, rectangular region, and single-window capture modes.
- * The captured image is resized to fit within maxDimension, encoded as base64,
- * and the temporary file is cleaned up before returning.
- *
- * @param options - Capture configuration. Defaults to full-screen PNG at 1024px max.
- * @returns Screenshot data including base64 content and dimensions.
- * @throws If screencapture fails, the window is not found, or image processing errors occur.
+ * Used when the Swift input-helper binary does not support the "screenshot"
+ * command (e.g. older binary version). This path spawns 3 child processes
+ * (screencapture + sips + sips) and works in physical pixels.
  */
-export async function captureScreen(
-  options: CaptureOptions = {},
+async function captureViaScreencaptureCLI(
+  mode: CaptureMode,
+  region: CaptureRegion | undefined,
+  windowTitle: string | undefined,
+  maxDimension: number,
+  format: ImageFormat,
 ): Promise<ScreenshotResult> {
-  const {
-    mode = "full",
-    region,
-    windowTitle,
-    maxDimension = DEFAULT_MAX_DIMENSION,
-    format = "png",
-    displayScaleFactor = 1,
-  } = options;
-
   const tmpPath = makeTmpPath(format);
 
   try {
@@ -189,37 +292,42 @@ export async function captureScreen(
       timeout: SCREENCAPTURE_TIMEOUT_MS,
     });
 
-    // Get original dimensions (physical pixels) before resizing
+    // Get original dimensions (physical pixels)
     const originalDims = await getImageDimensions(tmpPath);
 
-    // Compute logical dimensions (same coordinate system as CGEvent)
-    const logicalWidth = Math.round(originalDims.width / displayScaleFactor);
-    const logicalHeight = Math.round(originalDims.height / displayScaleFactor);
+    // Resize to fit within maxDimension (only if maxDimension > 0)
+    if (maxDimension > 0) {
+      await execFileAsync("sips", ["-Z", String(maxDimension), tmpPath], {
+        timeout: SCREENCAPTURE_TIMEOUT_MS,
+      });
+    }
 
-    // Resize to fit within maxDimension
-    await execFileAsync("sips", ["-Z", String(maxDimension), tmpPath], {
-      timeout: SCREENCAPTURE_TIMEOUT_MS,
-    });
-
-    // Get final dimensions after resizing
+    // Get final dimensions
     const finalDims = await getImageDimensions(tmpPath);
-
-    const scaleInfo =
-      logicalWidth === finalDims.width && logicalHeight === finalDims.height
-        ? `No resize needed (${finalDims.width}x${finalDims.height})`
-        : `Resized from ${logicalWidth}x${logicalHeight} to ${finalDims.width}x${finalDims.height}`;
 
     // Read file and encode to base64
     const buffer = await readFile(tmpPath);
     const base64 = buffer.toString("base64");
 
+    // In the legacy path, compute approximate scale factors.
+    // screencapture outputs physical pixels, so coordinates are approximate.
+    const scaleX =
+      finalDims.width !== originalDims.width
+        ? originalDims.width / finalDims.width
+        : 1;
+    const scaleY =
+      finalDims.height !== originalDims.height
+        ? originalDims.height / finalDims.height
+        : 1;
+
     return {
       base64,
       width: finalDims.width,
       height: finalDims.height,
-      scaleInfo,
-      screenWidth: logicalWidth,
-      screenHeight: logicalHeight,
+      originX: 0,
+      originY: 0,
+      scaleX,
+      scaleY,
     };
   } finally {
     // Clean up temporary file

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   clipboardToolDefinitions,
   clipboardToolHandlers,
 } from "./tools/clipboard.js";
+import { menuToolDefinitions, menuToolHandlers } from "./tools/menu.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
@@ -45,6 +46,7 @@ const allToolDefinitions = [
   ...keyboardToolDefinitions,
   ...windowToolDefinitions,
   ...clipboardToolDefinitions,
+  ...menuToolDefinitions,
 ];
 
 /** Unified handler map — tool name to async handler function. */
@@ -59,6 +61,7 @@ const allToolHandlers: Record<
   ...keyboardToolHandlers,
   ...windowToolHandlers,
   ...clipboardToolHandlers,
+  ...menuToolHandlers,
 };
 
 const server = new Server(

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ import {
   clipboardToolHandlers,
 } from "./tools/clipboard.js";
 import { menuToolDefinitions, menuToolHandlers } from "./tools/menu.js";
+import {
+  accessibilityToolDefinitions,
+  accessibilityToolHandlers,
+} from "./tools/accessibility.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
@@ -47,6 +51,7 @@ const allToolDefinitions = [
   ...windowToolDefinitions,
   ...clipboardToolDefinitions,
   ...menuToolDefinitions,
+  ...accessibilityToolDefinitions,
 ];
 
 /** Unified handler map — tool name to async handler function. */
@@ -62,6 +67,7 @@ const allToolHandlers: Record<
   ...windowToolHandlers,
   ...clipboardToolHandlers,
   ...menuToolHandlers,
+  ...accessibilityToolHandlers,
 };
 
 const server = new Server(

--- a/src/tools/accessibility.ts
+++ b/src/tools/accessibility.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { zodToToolInputSchema } from "../helpers/schema.js";
+import { runInputHelper } from "../helpers/input-helper.js";
+import { resolveAppName } from "../helpers/app-resolver.js";
+import { enqueue } from "../queue.js";
+
+// -- Schemas -----------------------------------------------------------------
+
+const GetUIElementsInputSchema = z.object({
+  app: z
+    .string()
+    .optional()
+    .describe(
+      "Target application name. Default: frontmost app. Supports fuzzy matching.",
+    ),
+  role: z
+    .string()
+    .optional()
+    .describe(
+      'Filter by AX role: "AXButton", "AXTextField", "AXStaticText", etc.',
+    ),
+  title: z
+    .string()
+    .optional()
+    .describe("Filter by element title (substring, case-insensitive)."),
+  max_depth: z
+    .number()
+    .int()
+    .min(1)
+    .max(10)
+    .default(5)
+    .describe("Max tree traversal depth (default: 5)."),
+});
+
+// -- Tool definitions --------------------------------------------------------
+
+export const accessibilityToolDefinitions: Tool[] = [
+  {
+    name: "get_ui_elements",
+    description:
+      "Query visible UI elements of an application via macOS Accessibility API. " +
+      "Returns element roles, titles, positions (screen coordinates), sizes, and states. " +
+      "Positions are in logical screen coordinates — pass directly to click tool. " +
+      "Coverage varies: native apps expose rich trees; Electron/web apps may expose partial trees; " +
+      "games/custom UIs may expose nothing. Requires Accessibility permission.",
+    inputSchema: zodToToolInputSchema(GetUIElementsInputSchema),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+];
+
+// -- Handlers ----------------------------------------------------------------
+
+/** Handle get_ui_elements tool call. */
+async function handleGetUIElements(
+  args: Record<string, unknown>,
+): Promise<CallToolResult> {
+  const parsed = GetUIElementsInputSchema.parse(args);
+
+  const helperArgs: Record<string, unknown> = {
+    max_depth: parsed.max_depth,
+  };
+  if (parsed.app) {
+    helperArgs.app = await resolveAppName(parsed.app);
+  }
+  if (parsed.role) helperArgs.role = parsed.role;
+  if (parsed.title) helperArgs.title = parsed.title;
+
+  const response = await runInputHelper("get_ui_elements", helperArgs);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(response, null, 2),
+      },
+    ],
+  };
+}
+
+// -- Dispatcher --------------------------------------------------------------
+
+/** Map of accessibility tool names to their handler functions (queued). */
+export const accessibilityToolHandlers: Record<
+  string,
+  (args: Record<string, unknown>) => Promise<CallToolResult>
+> = {
+  get_ui_elements: (args) => enqueue(() => handleGetUIElements(args)),
+};

--- a/src/tools/menu.ts
+++ b/src/tools/menu.ts
@@ -12,9 +12,7 @@ import { enqueue } from "../queue.js";
 
 const ClickMenuInputSchema = z.object({
   app: z.string().describe("Application name"),
-  path: z
-    .string()
-    .describe('Menu path, e.g. "File > Save As..."'),
+  path: z.string().describe('Menu path, e.g. "File > Save As..."'),
 });
 
 // -- Constants ---------------------------------------------------------------
@@ -76,7 +74,7 @@ function buildMenuClickScript(app: string, parts: string[]): string {
   chain += ` of menu "${root}" of menu bar item "${root}" of menu bar 1`;
 
   return [
-    "tell application \"System Events\"",
+    'tell application "System Events"',
     `  tell process "${safeApp}"`,
     `    ${chain}`,
     "  end tell",

--- a/src/tools/menu.ts
+++ b/src/tools/menu.ts
@@ -5,6 +5,7 @@ import {
   runAppleScript,
   escapeAppleScriptString,
 } from "../helpers/applescript.js";
+import { resolveAppName } from "../helpers/app-resolver.js";
 import { enqueue } from "../queue.js";
 
 // -- Schemas -----------------------------------------------------------------
@@ -104,7 +105,8 @@ async function handleClickMenu(
     };
   }
 
-  const script = buildMenuClickScript(parsed.app, parts);
+  const app = await resolveAppName(parsed.app);
+  const script = buildMenuClickScript(app, parts);
   await runAppleScript(script);
 
   return {

--- a/src/tools/menu.ts
+++ b/src/tools/menu.ts
@@ -1,0 +1,132 @@
+import { z } from "zod";
+import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { zodToToolInputSchema } from "../helpers/schema.js";
+import {
+  runAppleScript,
+  escapeAppleScriptString,
+} from "../helpers/applescript.js";
+import { enqueue } from "../queue.js";
+
+// -- Schemas -----------------------------------------------------------------
+
+const ClickMenuInputSchema = z.object({
+  app: z.string().describe("Application name"),
+  path: z
+    .string()
+    .describe('Menu path, e.g. "File > Save As..."'),
+});
+
+// -- Constants ---------------------------------------------------------------
+
+/** Minimum number of path segments required (menu bar item + menu item). */
+const MIN_PATH_SEGMENTS = 2;
+
+/** Delimiter used to split menu path segments. */
+const PATH_DELIMITER = " > ";
+
+// -- Tool definitions --------------------------------------------------------
+
+export const menuToolDefinitions: Tool[] = [
+  {
+    name: "click_menu",
+    description:
+      'Click a menu bar item in an application. Specify the menu path as "Menu > Submenu > Item" (e.g., "File > Save As...", "View > Sort By > Name").',
+    inputSchema: zodToToolInputSchema(ClickMenuInputSchema),
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+    },
+  },
+];
+
+// -- Helpers -----------------------------------------------------------------
+
+/**
+ * Build an AppleScript expression to click a menu item at the given path.
+ *
+ * Path segments are ordered root-to-leaf:
+ *   parts[0]       — menu bar item (top-level menu)
+ *   parts[1..n-2]  — intermediate submenus (if any)
+ *   parts[n-1]     — leaf menu item to click
+ *
+ * For 2 segments ("File > Save As..."):
+ *   click menu item "Save As..." of menu "File" of menu bar item "File" of menu bar 1
+ *
+ * For 3+ segments ("View > Sort By > Name"):
+ *   click menu item "Name" of menu "Sort By" of menu item "Sort By"
+ *     of menu "View" of menu bar item "View" of menu bar 1
+ */
+function buildMenuClickScript(app: string, parts: string[]): string {
+  const safeApp = escapeAppleScriptString(app);
+  const escaped = parts.map(escapeAppleScriptString);
+
+  const root = escaped[0];
+  const leaf = escaped[escaped.length - 1];
+
+  // Start with the leaf item
+  let chain = `click menu item "${leaf}"`;
+
+  // Traverse intermediate submenus from second-to-last down to index 1
+  for (let i = escaped.length - 2; i >= 1; i--) {
+    chain += ` of menu "${escaped[i]}" of menu item "${escaped[i]}"`;
+  }
+
+  // Attach to root menu bar item
+  chain += ` of menu "${root}" of menu bar item "${root}" of menu bar 1`;
+
+  return [
+    "tell application \"System Events\"",
+    `  tell process "${safeApp}"`,
+    `    ${chain}`,
+    "  end tell",
+    "end tell",
+  ].join("\n");
+}
+
+// -- Handlers ----------------------------------------------------------------
+
+/** Handle click_menu tool call. */
+async function handleClickMenu(
+  args: Record<string, unknown>,
+): Promise<CallToolResult> {
+  const parsed = ClickMenuInputSchema.parse(args);
+  const parts = parsed.path.split(PATH_DELIMITER);
+
+  if (parts.length < MIN_PATH_SEGMENTS) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Invalid menu path: expected at least ${MIN_PATH_SEGMENTS} segments separated by "${PATH_DELIMITER}", got ${parts.length}. Example: "File > Save As..."`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const script = buildMenuClickScript(parsed.app, parts);
+  await runAppleScript(script);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          success: true,
+          app: parsed.app,
+          path: parsed.path,
+        }),
+      },
+    ],
+  };
+}
+
+// -- Dispatcher --------------------------------------------------------------
+
+/** Map of menu tool names to their handler functions (queued). */
+export const menuToolHandlers: Record<
+  string,
+  (args: Record<string, unknown>) => Promise<CallToolResult>
+> = {
+  click_menu: (args) => enqueue(() => handleClickMenu(args)),
+};

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { captureScreen } from "../helpers/screencapture.js";
-import { runInputHelper } from "../helpers/input-helper.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
 import { DEFAULT_MAX_DIMENSION } from "../constants.js";
 import { enqueue } from "../queue.js";
@@ -8,21 +7,11 @@ import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 // -- Constants ---------------------------------------------------------------
 
-/** Minimum allowed value for max_dimension. */
+/** Minimum allowed value for max_dimension (when non-zero). */
 const MIN_MAX_DIMENSION = 256;
 
 /** Maximum allowed value for max_dimension. */
 const MAX_MAX_DIMENSION = 4096;
-
-// -- Response schemas (validate Swift helper output) -------------------------
-
-const DisplayScaleResponseSchema = z.object({
-  displays: z.array(
-    z.object({
-      scaleFactor: z.number(),
-    }),
-  ),
-});
 
 /** Permission setup instructions shown when screenshot capture fails. */
 const PERMISSION_INSTRUCTIONS =
@@ -76,11 +65,14 @@ const ScreenshotBaseSchema = z.object({
   max_dimension: z
     .number()
     .int()
-    .min(MIN_MAX_DIMENSION)
+    .min(0)
     .max(MAX_MAX_DIMENSION)
     .default(DEFAULT_MAX_DIMENSION)
+    .refine((v) => v === 0 || v >= MIN_MAX_DIMENSION, {
+      message: `max_dimension must be 0 (no resize) or between ${MIN_MAX_DIMENSION} and ${MAX_MAX_DIMENSION}`,
+    })
     .describe(
-      `Maximum width or height of the returned image (${MIN_MAX_DIMENSION}–${MAX_MAX_DIMENSION}, default ${DEFAULT_MAX_DIMENSION})`,
+      `Maximum width or height of the returned image. 0 means no resize (default). When set, must be ${MIN_MAX_DIMENSION}–${MAX_MAX_DIMENSION}.`,
     ),
   format: z
     .enum(["png", "jpeg"])
@@ -136,11 +128,6 @@ async function handleScreenshot(
   const parsed = ScreenshotInputSchema.parse(args);
 
   try {
-    // Get display scale factor for logical dimension computation
-    const displayResponse = await runInputHelper("display_info", {});
-    const { displays } = DisplayScaleResponseSchema.parse(displayResponse);
-    const scaleFactor = displays.length > 0 ? displays[0].scaleFactor : 1;
-
     const result = await captureScreen({
       mode: parsed.mode,
       region:
@@ -150,10 +137,20 @@ async function handleScreenshot(
       windowTitle: parsed.mode === "window" ? parsed.window_title : undefined,
       maxDimension: parsed.max_dimension,
       format: parsed.format,
-      displayScaleFactor: scaleFactor,
     });
 
     const mimeType = parsed.format === "jpeg" ? "image/jpeg" : "image/png";
+
+    // Build coordinate mapping hint for agents
+    const isIdentity =
+      result.scaleX === 1 &&
+      result.scaleY === 1 &&
+      result.originX === 0 &&
+      result.originY === 0;
+
+    const coordinateHint = isIdentity
+      ? "Coordinate mapping: screen = image pixel (1:1, no conversion needed)"
+      : `Coordinate mapping: screen_x = ${result.originX} + image_x * ${result.scaleX}, screen_y = ${result.originY} + image_y * ${result.scaleY}`;
 
     return {
       content: [
@@ -164,12 +161,7 @@ async function handleScreenshot(
         },
         {
           type: "text" as const,
-          text: [
-            `Image dimensions: ${result.width}x${result.height} (pixels)`,
-            `Scale: ${result.scaleInfo}`,
-            "Note: to convert image pixel positions to screen coordinates, " +
-              `multiply by (screen_dimension / image_dimension). Screen is ${result.screenWidth}x${result.screenHeight}.`,
-          ].join("\n"),
+          text: `Image: ${result.width}x${result.height}\n${coordinateHint}`,
         },
       ],
     };

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -7,6 +7,7 @@ import {
   escapeAppleScriptString,
 } from "../helpers/applescript.js";
 import { runInputHelper } from "../helpers/input-helper.js";
+import { resolveAppName } from "../helpers/app-resolver.js";
 import { OPEN_COMMAND_TIMEOUT_MS } from "../constants.js";
 import { enqueue } from "../queue.js";
 
@@ -74,7 +75,7 @@ export const windowToolDefinitions: Tool[] = [
   {
     name: "list_windows",
     description:
-      "List visible windows with their app name, title, ID, position, size, and minimized state. Optionally filter by application name.",
+      "List visible windows with their app name, title, ID, position, size, and minimized state. Optionally filter by application name. App name supports fuzzy matching (case-insensitive, partial names like 'chrome' for 'Google Chrome').",
     inputSchema: zodToToolInputSchema(ListWindowsInputSchema),
     annotations: {
       readOnlyHint: true,
@@ -84,7 +85,7 @@ export const windowToolDefinitions: Tool[] = [
   {
     name: "focus_window",
     description:
-      "Activate an application and optionally raise a specific window by title.",
+      "Activate an application and optionally raise a specific window by title. App name supports fuzzy matching.",
     inputSchema: zodToToolInputSchema(FocusWindowInputSchema),
     annotations: {
       readOnlyHint: false,
@@ -93,7 +94,8 @@ export const windowToolDefinitions: Tool[] = [
   },
   {
     name: "open_application",
-    description: "Launch an application by name or bundle identifier.",
+    description:
+      "Launch an application by name or bundle identifier. App name supports fuzzy matching (e.g. 'chrome' → 'Google Chrome').",
     inputSchema: zodToToolInputSchema(OpenApplicationInputSchema),
     annotations: {
       readOnlyHint: false,
@@ -126,9 +128,10 @@ async function handleListWindows(
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
   const parsed = ListWindowsInputSchema.parse(args);
+  const app = parsed.app ? await resolveAppName(parsed.app) : undefined;
   const response = await runInputHelper(
     "list_windows",
-    parsed.app ? { app: parsed.app } : {},
+    app ? { app } : {},
   );
   const result = ListWindowsResponseSchema.parse(response);
 
@@ -156,7 +159,8 @@ async function handleFocusWindow(
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
   const parsed = FocusWindowInputSchema.parse(args);
-  const safeApp = escapeAppleScriptString(parsed.app);
+  const app = await resolveAppName(parsed.app);
+  const safeApp = escapeAppleScriptString(app);
 
   // Activate the application
   let script = `tell application "${safeApp}" to activate`;
@@ -199,7 +203,10 @@ async function handleOpenApplication(
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
   const parsed = OpenApplicationInputSchema.parse(args);
-  const name = parsed.name;
+  // Skip resolution for bundle IDs — they must be passed verbatim
+  const name = isBundleId(parsed.name)
+    ? parsed.name
+    : await resolveAppName(parsed.name);
 
   // Determine whether to use -a (app name) or -b (bundle ID)
   const flag = isBundleId(name) ? "-b" : "-a";

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -129,10 +129,7 @@ async function handleListWindows(
 ): Promise<CallToolResult> {
   const parsed = ListWindowsInputSchema.parse(args);
   const app = parsed.app ? await resolveAppName(parsed.app) : undefined;
-  const response = await runInputHelper(
-    "list_windows",
-    app ? { app } : {},
-  );
+  const response = await runInputHelper("list_windows", app ? { app } : {});
   const result = ListWindowsResponseSchema.parse(response);
 
   const windows: WindowInfo[] = result.windows.map((w) => ({

--- a/swift/input-helper.swift
+++ b/swift/input-helper.swift
@@ -1,4 +1,5 @@
 import Carbon
+import Cocoa
 import CoreGraphics
 import Foundation
 import ImageIO
@@ -810,6 +811,171 @@ func handleScreenshot(_ args: [String: Any]) {
     ])
 }
 
+// MARK: - Accessibility UI Elements Handler
+
+/// Maximum number of elements to return from a single get_ui_elements query.
+/// Capped to prevent excessive output that would overwhelm LLM context windows.
+private let maxUIElements = 50
+
+/// Traverse the AX tree in breadth-first order, collecting element metadata.
+///
+/// Filters by role and title when specified. Stops when `maxUIElements` is
+/// reached or the tree is exhausted up to `maxDepth` levels.
+///
+/// - Parameters:
+///   - root: The root AXUIElement (typically an application element).
+///   - maxDepth: Maximum tree traversal depth.
+///   - roleFilter: Optional AX role string to match exactly (e.g. "AXButton").
+///   - titleFilter: Optional case-insensitive substring to match against title or description.
+/// - Returns: Array of element dictionaries with role, title, position, size, and states.
+func collectUIElements(
+    root: AXUIElement,
+    maxDepth: Int,
+    roleFilter: String?,
+    titleFilter: String?
+) -> [[String: Any]] {
+    var results: [[String: Any]] = []
+    var queue: [(element: AXUIElement, depth: Int)] = [(root, 0)]
+
+    while !queue.isEmpty && results.count < maxUIElements {
+        let (element, depth) = queue.removeFirst()
+        if depth > maxDepth { continue }
+
+        // Extract role
+        var roleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
+        let role = roleRef as? String ?? ""
+
+        // Extract title
+        var titleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXTitleAttribute as CFString, &titleRef)
+        let title = titleRef as? String
+
+        // Fallback: AXDescription
+        var descRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXDescriptionAttribute as CFString, &descRef)
+        let axDescription = descRef as? String
+
+        // Extract value
+        var valueRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
+        let value = valueRef as? String
+
+        // Extract position
+        var positionRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionRef)
+        var position = CGPoint.zero
+        if let positionValue = positionRef {
+            AXValueGetValue(positionValue as! AXValue, .cgPoint, &position)
+        }
+
+        // Extract size
+        var sizeRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeRef)
+        var size = CGSize.zero
+        if let sizeValue = sizeRef {
+            AXValueGetValue(sizeValue as! AXValue, .cgSize, &size)
+        }
+
+        // Extract enabled state
+        var enabledRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXEnabledAttribute as CFString, &enabledRef)
+        let enabled = enabledRef as? Bool ?? true
+
+        // Extract focused state
+        var focusedRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXFocusedAttribute as CFString, &focusedRef)
+        let focused = focusedRef as? Bool ?? false
+
+        // Apply filters
+        let displayTitle = title ?? axDescription
+        let passesRoleFilter = roleFilter == nil || role == roleFilter
+        let passesTitleFilter = titleFilter == nil ||
+            (displayTitle?.lowercased().contains(titleFilter!.lowercased()) ?? false)
+
+        // Include element if it has a meaningful role and passes all filters
+        if !role.isEmpty && passesRoleFilter && passesTitleFilter {
+            var entry: [String: Any] = [
+                "role": role,
+                "position": ["x": Int(position.x), "y": Int(position.y)],
+                "size": ["width": Int(size.width), "height": Int(size.height)],
+                "enabled": enabled,
+                "focused": focused,
+            ]
+            if let t = displayTitle, !t.isEmpty {
+                entry["title"] = t
+            }
+            if let v = value, !v.isEmpty {
+                entry["value"] = v
+            }
+            results.append(entry)
+        }
+
+        // Enqueue children for BFS traversal
+        if depth < maxDepth {
+            var childrenRef: CFTypeRef?
+            AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef)
+            if let children = childrenRef as? [AXUIElement] {
+                for child in children {
+                    queue.append((child, depth + 1))
+                }
+            }
+        }
+    }
+
+    return results
+}
+
+/// Handle the "get_ui_elements" command.
+///
+/// Queries visible UI elements of an application via the macOS Accessibility API.
+/// Uses BFS traversal with optional role and title filters.
+///
+/// Args: {"app":"optional", "role":"AXButton", "title":"substring", "max_depth":5}
+func handleGetUIElements(_ args: [String: Any]) {
+    let appName = args["app"] as? String
+    let roleFilter = args["role"] as? String
+    let titleFilter = args["title"] as? String
+    let maxDepth = args["max_depth"] as? Int ?? 5
+
+    // Resolve PID: fuzzy match against running apps, or use frontmost
+    let pid: pid_t
+    if let name = appName {
+        let apps = NSWorkspace.shared.runningApplications.filter {
+            $0.activationPolicy == .regular
+        }
+        let nameLower = name.lowercased()
+
+        let match = apps.first(where: { ($0.localizedName ?? "").lowercased() == nameLower })
+            ?? apps.first(where: { ($0.localizedName ?? "").lowercased().hasPrefix(nameLower) })
+            ?? apps.first(where: { ($0.localizedName ?? "").lowercased().contains(nameLower) })
+
+        guard let app = match else {
+            fail("get_ui_elements: no running application found matching '\(name)'")
+        }
+        pid = app.processIdentifier
+    } else {
+        guard let frontmost = NSWorkspace.shared.frontmostApplication else {
+            fail("get_ui_elements: no frontmost application found")
+        }
+        pid = frontmost.processIdentifier
+    }
+
+    let appElement = AXUIElementCreateApplication(pid)
+    let elements = collectUIElements(
+        root: appElement,
+        maxDepth: maxDepth,
+        roleFilter: roleFilter,
+        titleFilter: titleFilter
+    )
+
+    outputJSON([
+        "success": true,
+        "elements": elements,
+        "count": elements.count,
+    ])
+}
+
 // MARK: - Main Entry Point
 
 let arguments = CommandLine.arguments
@@ -852,6 +1018,8 @@ case "list_windows":
     handleListWindows(args)
 case "screenshot":
     handleScreenshot(args)
+case "get_ui_elements":
+    handleGetUIElements(args)
 default:
     fail("unknown command: \(command)")
 }

--- a/swift/input-helper.swift
+++ b/swift/input-helper.swift
@@ -1,6 +1,7 @@
 import Carbon
 import CoreGraphics
 import Foundation
+import ImageIO
 
 // MARK: - Output Helpers
 
@@ -556,6 +557,259 @@ func handleListWindows(_ args: [String: Any]) {
     outputJSON(["success": true, "windows": windows])
 }
 
+// MARK: - Screenshot Helpers
+
+/// Resize a CGImage to the given dimensions using high-quality interpolation.
+///
+/// Returns the original image unchanged if newWidth/newHeight match the input.
+func resizeImage(_ image: CGImage, newWidth: Int, newHeight: Int) -> CGImage {
+    if image.width == newWidth && image.height == newHeight {
+        return image
+    }
+
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue
+        | CGBitmapInfo.byteOrder32Little.rawValue
+
+    guard let context = CGContext(
+        data: nil,
+        width: newWidth,
+        height: newHeight,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: colorSpace,
+        bitmapInfo: bitmapInfo
+    ) else {
+        fail("screenshot: failed to create resize context")
+    }
+
+    context.interpolationQuality = .high
+    context.draw(image, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
+
+    guard let resized = context.makeImage() else {
+        fail("screenshot: failed to create resized image")
+    }
+    return resized
+}
+
+/// Compute the logical bounding box of all active displays.
+///
+/// Returns the union of all display bounds in logical points — the same
+/// coordinate system as CGEvent and CGWindowListCopyWindowInfo.
+func logicalScreenBounds() -> CGRect {
+    var displayIDs = [CGDirectDisplayID](repeating: 0, count: Int(maxDisplayCount))
+    var count: UInt32 = 0
+    CGGetActiveDisplayList(maxDisplayCount, &displayIDs, &count)
+
+    var union = CGRect.null
+    for i in 0..<Int(count) {
+        union = union.union(CGDisplayBounds(displayIDs[i]))
+    }
+    return union
+}
+
+/// Encode a CGImage to PNG or JPEG data using ImageIO.
+func encodeImage(_ image: CGImage, format: String) -> Data {
+    let uti: CFString = format == "jpeg"
+        ? "public.jpeg" as CFString
+        : "public.png" as CFString
+    let imageData = NSMutableData()
+
+    guard let destination = CGImageDestinationCreateWithData(
+        imageData, uti, 1, nil
+    ) else {
+        fail("screenshot: failed to create image destination")
+    }
+
+    CGImageDestinationAddImage(destination, image, nil)
+
+    guard CGImageDestinationFinalize(destination) else {
+        fail("screenshot: failed to finalize image encoding")
+    }
+
+    return imageData as Data
+}
+
+// MARK: - Screenshot Command Handler
+
+/// Handle the "screenshot" command.
+///
+/// Captures a screenshot using CGWindowListCreateImage and normalizes the
+/// output to logical pixels (matching screen coordinates). On macOS versions
+/// where CGWindowListCreateImage returns Retina (2x) pixels, the image is
+/// downscaled to logical resolution automatically.
+///
+/// Args: {"mode":"full"|"region"|"window", "x":Int, "y":Int, "w":Int, "h":Int,
+///        "window_title":"...", "max_dimension":0, "format":"png"|"jpeg"}
+func handleScreenshot(_ args: [String: Any]) {
+    let mode = args["mode"] as? String ?? "full"
+    let maxDimension = args["max_dimension"] as? Int ?? 0
+    let format = args["format"] as? String ?? "png"
+
+    var capturedImage: CGImage?
+    var originX: CGFloat = 0
+    var originY: CGFloat = 0
+    // Expected logical size — used to detect and correct Retina captures
+    var expectedLogicalWidth: CGFloat = 0
+    var expectedLogicalHeight: CGFloat = 0
+
+    switch mode {
+    case "full":
+        capturedImage = CGWindowListCreateImage(
+            .infinite,
+            .optionOnScreenOnly,
+            kCGNullWindowID,
+            []
+        )
+        let screenBounds = logicalScreenBounds()
+        expectedLogicalWidth = screenBounds.size.width
+        expectedLogicalHeight = screenBounds.size.height
+
+    case "region":
+        let rx = requireCGFloat(args, key: "x", command: "screenshot")
+        let ry = requireCGFloat(args, key: "y", command: "screenshot")
+        let rw = requireCGFloat(args, key: "w", command: "screenshot")
+        let rh = requireCGFloat(args, key: "h", command: "screenshot")
+        let rect = CGRect(x: rx, y: ry, width: rw, height: rh)
+        originX = rx
+        originY = ry
+        expectedLogicalWidth = rw
+        expectedLogicalHeight = rh
+        capturedImage = CGWindowListCreateImage(
+            rect,
+            .optionOnScreenOnly,
+            kCGNullWindowID,
+            []
+        )
+
+    case "window":
+        guard let windowTitle = args["window_title"] as? String,
+              !windowTitle.isEmpty else {
+            fail("screenshot: missing required 'window_title' for window mode")
+        }
+
+        guard let windowList = CGWindowListCopyWindowInfo(
+            [.optionAll, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] else {
+            fail("screenshot: failed to enumerate windows")
+        }
+
+        let titleLower = windowTitle.lowercased()
+        var foundWindowID: CGWindowID?
+        var foundBounds: CGRect?
+
+        for window in windowList {
+            guard let ownerName = window[kCGWindowOwnerName as String] as? String,
+                  let windowNumber = window[kCGWindowNumber as String] as? Int,
+                  let bounds = window[kCGWindowBounds as String] as? [String: Any]
+            else {
+                continue
+            }
+
+            let layer = window[kCGWindowLayer as String] as? Int ?? -1
+            if layer != 0 { continue }
+
+            let title = window[kCGWindowName as String] as? String ?? ""
+
+            // Case-insensitive substring match on title or owner name
+            if title.lowercased().contains(titleLower)
+                || ownerName.lowercased().contains(titleLower)
+            {
+                guard let bx = bounds["X"] as? Double,
+                      let by = bounds["Y"] as? Double,
+                      let bw = bounds["Width"] as? Double,
+                      let bh = bounds["Height"] as? Double else {
+                    continue
+                }
+                if bw < 1 || bh < 1 { continue }
+
+                foundWindowID = CGWindowID(windowNumber)
+                foundBounds = CGRect(x: bx, y: by, width: bw, height: bh)
+                break
+            }
+        }
+
+        guard let windowID = foundWindowID, let windowBounds = foundBounds else {
+            fail("screenshot: no window found matching '\(windowTitle)'")
+        }
+
+        originX = windowBounds.origin.x
+        originY = windowBounds.origin.y
+        expectedLogicalWidth = windowBounds.size.width
+        expectedLogicalHeight = windowBounds.size.height
+
+        capturedImage = CGWindowListCreateImage(
+            .null,
+            .optionIncludingWindow,
+            windowID,
+            []
+        )
+
+    default:
+        fail("screenshot: unknown mode '\(mode)' — expected full, region, or window")
+    }
+
+    guard let rawImage = capturedImage else {
+        fail("screenshot: CGWindowListCreateImage returned nil — Screen Recording permission may be required")
+    }
+
+    // Normalize to logical pixels. On some macOS versions (15+),
+    // CGWindowListCreateImage returns Retina-resolution images even without
+    // .bestResolution. Detect this by comparing captured size to expected
+    // logical size, and downscale if needed.
+    var logicalImage = rawImage
+    let logicalW = Int(expectedLogicalWidth)
+    let logicalH = Int(expectedLogicalHeight)
+
+    if logicalW > 0 && logicalH > 0
+        && (rawImage.width > logicalW || rawImage.height > logicalH)
+    {
+        logicalImage = resizeImage(rawImage, newWidth: logicalW, newHeight: logicalH)
+    }
+
+    // The "logical size" is what we use for coordinate math from here on
+    let logicalWidth = logicalImage.width
+    let logicalHeight = logicalImage.height
+
+    // Apply max_dimension resize on top of the logical image
+    var outputImage = logicalImage
+    if maxDimension > 0 && max(logicalWidth, logicalHeight) > maxDimension {
+        let scale = CGFloat(maxDimension) / CGFloat(max(logicalWidth, logicalHeight))
+        let newWidth = Int(CGFloat(logicalWidth) * scale)
+        let newHeight = Int(CGFloat(logicalHeight) * scale)
+        outputImage = resizeImage(logicalImage, newWidth: newWidth, newHeight: newHeight)
+    }
+
+    let outputWidth = outputImage.width
+    let outputHeight = outputImage.height
+
+    // Encode to PNG or JPEG
+    let encoded = encodeImage(outputImage, format: format)
+    let base64 = encoded.base64EncodedString()
+
+    // Compute scale factors for coordinate mapping.
+    // scale converts image pixels to logical screen offsets:
+    //   screen_x = origin_x + image_x * scale_x
+    var scaleX: Double = 1.0
+    var scaleY: Double = 1.0
+    if logicalWidth != outputWidth || logicalHeight != outputHeight {
+        scaleX = Double(logicalWidth) / Double(outputWidth)
+        scaleY = Double(logicalHeight) / Double(outputHeight)
+    }
+
+    outputJSON([
+        "success": true,
+        "base64": base64,
+        "width": outputWidth,
+        "height": outputHeight,
+        "origin_x": Double(originX),
+        "origin_y": Double(originY),
+        "scale_x": scaleX,
+        "scale_y": scaleY,
+    ])
+}
+
 // MARK: - Main Entry Point
 
 let arguments = CommandLine.arguments
@@ -596,6 +850,8 @@ case "display_info":
     handleDisplayInfo()
 case "list_windows":
     handleListWindows(args)
+case "screenshot":
+    handleScreenshot(args)
 default:
     fail("unknown command: \(command)")
 }


### PR DESCRIPTION
## Summary

- **Screenshot upgrade**: Replace 3-process `screencapture` + `sips` pipeline with built-in `CGWindowListCreateImage` in Swift. Captures at logical resolution (1:1 coordinate mapping by default). Default `max_dimension` changed from 1024 to 0 (no resize). Universal coordinate formula: `screen = origin + pixel * scale`.
- **`click_menu` tool**: Click menu bar items by path (e.g., `"File > Save As..."`). Supports arbitrarily nested submenus via AppleScript System Events.
- **Fuzzy app name matching**: `"chrome"` → `"Google Chrome"`, `"code"` → `"Code"`. Applied to `list_windows`, `focus_window`, `open_application`, and `click_menu`.
- **`get_ui_elements` tool**: Semantic UI element discovery via macOS Accessibility API. BFS traversal with role/title filters. Returns positions in logical screen coordinates for direct use with `click`.
- Tool count: 16 → 18 (within ≤ 20 limit)
- Version: 0.1.0 → 0.2.0

## Key technical decisions

- `CGWindowListCreateImage` without `.bestResolution` flag outputs logical pixels, but macOS 15+ returns Retina (2x) regardless — auto-detection and downscaling added
- `screencapture` CLI kept as fallback for old binary versions
- AX element cap at 50 to keep LLM context manageable

## Test plan

- [x] Full-screen screenshot: 1470x956 logical, origin=(0,0), scale=(1,1)
- [x] Scaled screenshot (max_dimension=1024): correct scale_x/scale_y
- [x] Region capture: correct origin
- [x] Window capture (Calculator): correct origin from window bounds
- [x] click_menu: verified with Finder Edit > Select All
- [x] Fuzzy matching: "chrome" → "Google Chrome", "finder" → "Finder"
- [x] get_ui_elements: Calculator buttons with positions, Finder buttons
- [x] Schema audit: all enums on string types (Gemini compatible)
- [x] Build: Swift + TypeScript + ESLint + Prettier all pass