### PR TITLE
fix(screenshot): avoid stdio buffer overflow by writing image to temp file

### DIFF
--- a/src/helpers/screencapture.ts
+++ b/src/helpers/screencapture.ts
@@ -60,7 +60,7 @@ export interface ScreenshotResult {
 /** Schema shape for the Swift input-helper screenshot response. */
 interface SwiftScreenshotResponse {
   success: boolean;
-  base64: string;
+  base64?: string;
   width: number;
   height: number;
   origin_x: number;
@@ -130,10 +130,13 @@ async function captureViaInputHelper(
   maxDimension: number,
   format: ImageFormat,
 ): Promise<ScreenshotResult> {
+  const tmpPath = makeTmpPath(format);
+
   const helperArgs: Record<string, unknown> = {
     mode,
     max_dimension: maxDimension,
     format,
+    output_path: tmpPath,
   };
 
   if (mode === "region" && region) {
@@ -147,24 +150,31 @@ async function captureViaInputHelper(
     helperArgs.window_title = windowTitle;
   }
 
-  const response = (await runInputHelper(
-    "screenshot",
-    helperArgs,
-  )) as unknown as SwiftScreenshotResponse;
+  try {
+    const response = (await runInputHelper(
+      "screenshot",
+      helperArgs,
+    )) as unknown as SwiftScreenshotResponse;
 
-  if (!response.success) {
-    throw new Error(response.error ?? "Screenshot capture failed");
+    if (!response.success) {
+      throw new Error(response.error ?? "Screenshot capture failed");
+    }
+
+    const buffer = await readFile(tmpPath);
+    const base64 = buffer.toString("base64");
+
+    return {
+      base64,
+      width: response.width,
+      height: response.height,
+      originX: response.origin_x,
+      originY: response.origin_y,
+      scaleX: response.scale_x,
+      scaleY: response.scale_y,
+    };
+  } finally {
+    await unlink(tmpPath).catch(() => {});
   }
-
-  return {
-    base64: response.base64,
-    width: response.width,
-    height: response.height,
-    originX: response.origin_x,
-    originY: response.origin_y,
-    scaleX: response.scale_x,
-    scaleY: response.scale_y,
-  };
 }
 
 // -- Fallback path: screencapture CLI ----------------------------------------

--- a/swift/input-helper.swift
+++ b/swift/input-helper.swift
@@ -787,7 +787,6 @@ func handleScreenshot(_ args: [String: Any]) {
 
     // Encode to PNG or JPEG
     let encoded = encodeImage(outputImage, format: format)
-    let base64 = encoded.base64EncodedString()
 
     // Compute scale factors for coordinate mapping.
     // scale converts image pixels to logical screen offsets:
@@ -799,16 +798,28 @@ func handleScreenshot(_ args: [String: Any]) {
         scaleY = Double(logicalHeight) / Double(outputHeight)
     }
 
-    outputJSON([
+    var result: [String: Any] = [
         "success": true,
-        "base64": base64,
         "width": outputWidth,
         "height": outputHeight,
         "origin_x": Double(originX),
         "origin_y": Double(originY),
         "scale_x": scaleX,
         "scale_y": scaleY,
-    ])
+    ]
+
+    if let outputPath = args["output_path"] as? String {
+        let url = URL(fileURLWithPath: outputPath)
+        do {
+            try encoded.write(to: url)
+        } catch {
+            fail("screenshot: failed to write image to \(outputPath) — \(error.localizedDescription)")
+        }
+    } else {
+        result["base64"] = encoded.base64EncodedString()
+    }
+
+    outputJSON(result)
 }
 
 // MARK: - Accessibility UI Elements Handler


### PR DESCRIPTION
## Summary

- **Root cause:** `captureViaInputHelper` calls the Swift binary via `execFileAsync` (stdio), which returns the screenshot as base64-encoded JSON on stdout. Node.js's default `maxBuffer` (1 MB) is too small for full-screen screenshots, causing `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` crashes.
- **Fix:** The Swift `screenshot` command now accepts an optional `output_path` argument. When provided, it writes raw image bytes to that file path instead of returning base64 via stdout, and the JSON response contains only metadata. The TypeScript side generates a temp path via `makeTmpPath()`, passes it to Swift, reads the file after the call, encodes to base64, and cleans up in a `try/finally`.
- **Precedent:** The legacy fallback path `captureViaScreencaptureCLI` already uses this exact temp-file + `try/finally` pattern. The Swift binary retains backward compatibility — omitting `output_path` preserves the original base64-in-JSON behavior.

## Test plan

- [x] Run `pnpm build` and `pnpm build:swift` — both pass
- [x] Run `pnpm lint` — no warnings or errors
- [x] Take a full-screen screenshot via MCP — verify image is returned correctly
- [x] Take a region screenshot — verify coordinates and image content
- [x] Take a window screenshot — verify correct window is captured
- [x] Verify no temp files are left behind in `/tmp/` after capture