### PR TITLE
fix: security hardening for v1.0.0

### DIFF
--- a/src/__tests__/helpers/applescript.test.ts
+++ b/src/__tests__/helpers/applescript.test.ts
@@ -70,7 +70,7 @@ describe("escapeAppleScriptString", () => {
   });
 
   it("strips mixed control characters while preserving unicode", () => {
-    expect(escapeAppleScriptString("café\n你好\t\"world\"\r\x00")).toBe(
+    expect(escapeAppleScriptString('café\n你好\t"world"\r\x00')).toBe(
       'café你好\\"world\\"',
     );
   });

--- a/src/__tests__/helpers/applescript.test.ts
+++ b/src/__tests__/helpers/applescript.test.ts
@@ -48,6 +48,38 @@ describe("escapeAppleScriptString", () => {
   it("handles string with only special characters", () => {
     expect(escapeAppleScriptString('""\\\\')).toBe('\\"\\"\\\\\\\\');
   });
+
+  it("strips newline characters", () => {
+    expect(escapeAppleScriptString("hello\nworld")).toBe("helloworld");
+  });
+
+  it("strips carriage return characters", () => {
+    expect(escapeAppleScriptString("hello\rworld")).toBe("helloworld");
+  });
+
+  it("strips null bytes", () => {
+    expect(escapeAppleScriptString("hello\x00world")).toBe("helloworld");
+  });
+
+  it("strips tab characters", () => {
+    expect(escapeAppleScriptString("hello\tworld")).toBe("helloworld");
+  });
+
+  it("strips DEL character (U+007F)", () => {
+    expect(escapeAppleScriptString("hello\x7fworld")).toBe("helloworld");
+  });
+
+  it("strips mixed control characters while preserving unicode", () => {
+    expect(escapeAppleScriptString("café\n你好\t\"world\"\r\x00")).toBe(
+      'café你好\\"world\\"',
+    );
+  });
+
+  it("preserves unicode characters above U+007F", () => {
+    expect(escapeAppleScriptString("日本語 émojis 🎉")).toBe(
+      "日本語 émojis 🎉",
+    );
+  });
 });
 
 describe("parseAppleScriptError", () => {

--- a/src/__tests__/tools/accessibility.test.ts
+++ b/src/__tests__/tools/accessibility.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { z, ZodError } from "zod";
 
+// Must mirror src/tools/accessibility.ts
 const GetUIElementsInputSchema = z.object({
-  app: z.string().optional(),
-  role: z.string().optional(),
-  title: z.string().optional(),
+  app: z.string().max(1_000).optional(),
+  role: z.string().max(200).optional(),
+  title: z.string().max(1_000).optional(),
   max_depth: z.number().int().min(1).max(10).default(5),
 });
 
@@ -56,5 +57,23 @@ describe("get_ui_elements schema", () => {
     expect(() => GetUIElementsInputSchema.parse({ max_depth: 3.5 })).toThrow(
       ZodError,
     );
+  });
+
+  it("rejects app exceeding max length (1000)", () => {
+    expect(() =>
+      GetUIElementsInputSchema.parse({ app: "a".repeat(1_001) }),
+    ).toThrow(ZodError);
+  });
+
+  it("rejects role exceeding max length (200)", () => {
+    expect(() =>
+      GetUIElementsInputSchema.parse({ role: "a".repeat(201) }),
+    ).toThrow(ZodError);
+  });
+
+  it("rejects title exceeding max length (1000)", () => {
+    expect(() =>
+      GetUIElementsInputSchema.parse({ title: "a".repeat(1_001) }),
+    ).toThrow(ZodError);
   });
 });

--- a/src/__tests__/tools/clipboard.test.ts
+++ b/src/__tests__/tools/clipboard.test.ts
@@ -4,7 +4,7 @@ import { z, ZodError } from "zod";
 const ClipboardReadInputSchema = z.object({});
 
 const ClipboardWriteInputSchema = z.object({
-  text: z.string(),
+  text: z.string().max(100_000),
 });
 
 describe("clipboard_read schema", () => {
@@ -33,5 +33,18 @@ describe("clipboard_write schema", () => {
     expect(() => ClipboardWriteInputSchema.parse({ text: 123 })).toThrow(
       ZodError,
     );
+  });
+
+  it("rejects text exceeding max length (100000)", () => {
+    expect(() =>
+      ClipboardWriteInputSchema.parse({ text: "a".repeat(100_001) }),
+    ).toThrow(ZodError);
+  });
+
+  it("accepts text at max length (100000)", () => {
+    const result = ClipboardWriteInputSchema.parse({
+      text: "a".repeat(100_000),
+    });
+    expect(result.text).toHaveLength(100_000);
   });
 });

--- a/src/__tests__/tools/keyboard.test.ts
+++ b/src/__tests__/tools/keyboard.test.ts
@@ -17,13 +17,13 @@ import { keyboardToolHandlers } from "../../tools/keyboard.js";
 
 const mockExecFileAsync = vi.mocked(execFileAsync);
 
-// Re-create schemas for validation tests
+// Re-create schemas for validation tests (must mirror src/tools/keyboard.ts)
 const TypeTextInputSchema = z.object({
-  text: z.string().min(1),
+  text: z.string().min(1).max(100_000),
 });
 
 const PressKeyInputSchema = z.object({
-  key: z.string().min(1),
+  key: z.string().min(1).max(200),
 });
 
 describe("type_text schema", () => {
@@ -44,6 +44,17 @@ describe("type_text schema", () => {
   it("rejects missing text", () => {
     expect(() => TypeTextInputSchema.parse({})).toThrow(ZodError);
   });
+
+  it("rejects text exceeding max length (100000)", () => {
+    expect(() =>
+      TypeTextInputSchema.parse({ text: "a".repeat(100_001) }),
+    ).toThrow(ZodError);
+  });
+
+  it("accepts text at max length (100000)", () => {
+    const result = TypeTextInputSchema.parse({ text: "a".repeat(100_000) });
+    expect(result.text).toHaveLength(100_000);
+  });
 });
 
 describe("press_key schema", () => {
@@ -59,6 +70,17 @@ describe("press_key schema", () => {
 
   it("rejects empty key", () => {
     expect(() => PressKeyInputSchema.parse({ key: "" })).toThrow(ZodError);
+  });
+
+  it("rejects key exceeding max length (200)", () => {
+    expect(() =>
+      PressKeyInputSchema.parse({ key: "a".repeat(201) }),
+    ).toThrow(ZodError);
+  });
+
+  it("accepts key at max length (200)", () => {
+    const result = PressKeyInputSchema.parse({ key: "a".repeat(200) });
+    expect(result.key).toHaveLength(200);
   });
 });
 

--- a/src/__tests__/tools/keyboard.test.ts
+++ b/src/__tests__/tools/keyboard.test.ts
@@ -73,9 +73,9 @@ describe("press_key schema", () => {
   });
 
   it("rejects key exceeding max length (200)", () => {
-    expect(() =>
-      PressKeyInputSchema.parse({ key: "a".repeat(201) }),
-    ).toThrow(ZodError);
+    expect(() => PressKeyInputSchema.parse({ key: "a".repeat(201) })).toThrow(
+      ZodError,
+    );
   });
 
   it("accepts key at max length (200)", () => {

--- a/src/__tests__/tools/menu.test.ts
+++ b/src/__tests__/tools/menu.test.ts
@@ -19,10 +19,10 @@ import { menuToolHandlers } from "../../tools/menu.js";
 
 const mockRunAppleScript = vi.mocked(runAppleScript);
 
-// Schema
+// Schema (must mirror src/tools/menu.ts)
 const ClickMenuInputSchema = z.object({
-  app: z.string(),
-  path: z.string(),
+  app: z.string().max(1_000),
+  path: z.string().max(1_000),
 });
 
 describe("click_menu schema", () => {
@@ -45,6 +45,24 @@ describe("click_menu schema", () => {
     expect(() => ClickMenuInputSchema.parse({ app: "Finder" })).toThrow(
       ZodError,
     );
+  });
+
+  it("rejects app exceeding max length (1000)", () => {
+    expect(() =>
+      ClickMenuInputSchema.parse({
+        app: "a".repeat(1_001),
+        path: "File > Save",
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("rejects path exceeding max length (1000)", () => {
+    expect(() =>
+      ClickMenuInputSchema.parse({
+        app: "Finder",
+        path: "a".repeat(1_001),
+      }),
+    ).toThrow(ZodError);
   });
 });
 

--- a/src/__tests__/tools/screenshot.test.ts
+++ b/src/__tests__/tools/screenshot.test.ts
@@ -14,7 +14,7 @@ const ScreenshotBaseSchema = z.object({
   y: z.number().int().min(0).optional(),
   width: z.number().int().min(1).optional(),
   height: z.number().int().min(1).optional(),
-  window_title: z.string().min(1).optional(),
+  window_title: z.string().min(1).max(1_000).optional(),
   max_dimension: z
     .number()
     .int()
@@ -106,6 +106,15 @@ describe("screenshot schema validation", () => {
     expect(() => ScreenshotInputSchema.parse({ mode: "window" })).toThrow(
       ZodError,
     );
+  });
+
+  it("rejects window_title exceeding max length (1000)", () => {
+    expect(() =>
+      ScreenshotInputSchema.parse({
+        mode: "window",
+        window_title: "a".repeat(1_001),
+      }),
+    ).toThrow(ZodError);
   });
 
   it("rejects max_dimension between 1 and 255", () => {

--- a/src/__tests__/tools/window.test.ts
+++ b/src/__tests__/tools/window.test.ts
@@ -2,18 +2,18 @@ import { describe, it, expect } from "vitest";
 import { z, ZodError } from "zod";
 import { isBundleId, ListWindowsResponseSchema } from "../../tools/window.js";
 
-// Re-create schemas for validation tests
+// Re-create schemas for validation tests (must mirror src/tools/window.ts)
 const ListWindowsInputSchema = z.object({
-  app: z.string().optional(),
+  app: z.string().max(1_000).optional(),
 });
 
 const FocusWindowInputSchema = z.object({
-  app: z.string(),
-  title: z.string().optional(),
+  app: z.string().max(1_000),
+  title: z.string().max(1_000).optional(),
 });
 
 const OpenApplicationInputSchema = z.object({
-  name: z.string(),
+  name: z.string().max(1_000),
 });
 
 describe("list_windows schema", () => {
@@ -25,6 +25,12 @@ describe("list_windows schema", () => {
   it("accepts app filter", () => {
     const result = ListWindowsInputSchema.parse({ app: "Safari" });
     expect(result.app).toBe("Safari");
+  });
+
+  it("rejects app exceeding max length (1000)", () => {
+    expect(() =>
+      ListWindowsInputSchema.parse({ app: "a".repeat(1_001) }),
+    ).toThrow(ZodError);
   });
 });
 
@@ -45,6 +51,21 @@ describe("focus_window schema", () => {
   it("rejects missing app", () => {
     expect(() => FocusWindowInputSchema.parse({})).toThrow(ZodError);
   });
+
+  it("rejects app exceeding max length (1000)", () => {
+    expect(() =>
+      FocusWindowInputSchema.parse({ app: "a".repeat(1_001) }),
+    ).toThrow(ZodError);
+  });
+
+  it("rejects title exceeding max length (1000)", () => {
+    expect(() =>
+      FocusWindowInputSchema.parse({
+        app: "Safari",
+        title: "a".repeat(1_001),
+      }),
+    ).toThrow(ZodError);
+  });
 });
 
 describe("open_application schema", () => {
@@ -55,6 +76,12 @@ describe("open_application schema", () => {
 
   it("rejects missing name", () => {
     expect(() => OpenApplicationInputSchema.parse({})).toThrow(ZodError);
+  });
+
+  it("rejects name exceeding max length (1000)", () => {
+    expect(() =>
+      OpenApplicationInputSchema.parse({ name: "a".repeat(1_001) }),
+    ).toThrow(ZodError);
   });
 });
 

--- a/src/helpers/applescript.ts
+++ b/src/helpers/applescript.ts
@@ -4,13 +4,24 @@ import { APPLESCRIPT_TIMEOUT_MS } from "../constants.js";
 /**
  * Escape a string for safe interpolation inside AppleScript double-quoted literals.
  *
- * Escapes backslashes first, then double quotes (order matters).
+ * First strips all C0 control characters (U+0000–U+001F) and DEL (U+007F) — AppleScript
+ * has no escape syntax for these in double-quoted strings. Then escapes backslashes
+ * and double quotes (order matters).
+ *
+ * Unicode above U+007F is safe (AppleScript handles UTF-8 natively).
  *
  * @param str - The raw string to escape.
  * @returns The escaped string safe for use inside AppleScript `"..."`.
  */
+/** Matches C0 control characters (U+0000–U+001F) and DEL (U+007F). */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS_RE = /[\x00-\x1f\x7f]/g;
+
 export function escapeAppleScriptString(str: string): string {
-  return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return str
+    .replace(CONTROL_CHARS_RE, "")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
 }
 
 /**

--- a/src/tools/accessibility.ts
+++ b/src/tools/accessibility.ts
@@ -10,18 +10,21 @@ import { enqueue } from "../queue.js";
 const GetUIElementsInputSchema = z.object({
   app: z
     .string()
+    .max(1_000)
     .optional()
     .describe(
       "Target application name. Default: frontmost app. Supports fuzzy matching.",
     ),
   role: z
     .string()
+    .max(200)
     .optional()
     .describe(
       'Filter by AX role: "AXButton", "AXTextField", "AXStaticText", etc.',
     ),
   title: z
     .string()
+    .max(1_000)
     .optional()
     .describe("Filter by element title (substring, case-insensitive)."),
   max_depth: z
@@ -41,6 +44,7 @@ export const accessibilityToolDefinitions: Tool[] = [
     description:
       "Query visible UI elements of an application via macOS Accessibility API. " +
       "Returns element roles, titles, positions (screen coordinates), sizes, and states. " +
+      "May return text content from visible UI elements including sensitive data (passwords in non-secure fields, messages, etc.). " +
       "Positions are in logical screen coordinates — pass directly to click tool. " +
       "Coverage varies: native apps expose rich trees; Electron/web apps may expose partial trees; " +
       "games/custom UIs may expose nothing. Requires Accessibility permission.",

--- a/src/tools/clipboard.ts
+++ b/src/tools/clipboard.ts
@@ -9,7 +9,7 @@ import { enqueue } from "../queue.js";
 const ClipboardReadInputSchema = z.object({});
 
 const ClipboardWriteInputSchema = z.object({
-  text: z.string().describe("Text to write to the clipboard."),
+  text: z.string().max(100_000).describe("Text to write to the clipboard."),
 });
 
 // -- Tool definitions --------------------------------------------------------

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -46,7 +46,7 @@ const KEY_NAME_EXAMPLES = [
 ];
 
 /** Delay after paste before restoring clipboard (ms). */
-const PASTE_SETTLE_MS = 50;
+const PASTE_SETTLE_MS = 100;
 
 // -- Schemas -----------------------------------------------------------------
 
@@ -54,6 +54,7 @@ const TypeTextInputSchema = z.object({
   text: z
     .string()
     .min(1)
+    .max(100_000)
     .describe("Text to type. Supports full Unicode including CJK and emoji."),
 });
 
@@ -61,6 +62,7 @@ const PressKeyInputSchema = z.object({
   key: z
     .string()
     .min(1)
+    .max(200)
     .describe(
       'Key combo string. Examples: "Return", "cmd+c", "ctrl+shift+F5", "alt+Tab".',
     ),
@@ -72,7 +74,7 @@ export const keyboardToolDefinitions: Tool[] = [
   {
     name: "type_text",
     description:
-      'Type text at the current cursor position using clipboard paste. Supports full Unicode including CJK characters and emoji. If secure input is active (e.g. password fields), returns a note suggesting clipboard_write + press_key("cmd+v") as an alternative.',
+      'Type text at the current cursor position using clipboard paste. Supports full Unicode including CJK characters and emoji. Temporarily replaces clipboard contents. Non-text clipboard content (images, files) will be lost permanently. If secure input is active (e.g. password fields), returns a note suggesting clipboard_write + press_key("cmd+v") as an alternative.',
     inputSchema: zodToToolInputSchema(TypeTextInputSchema),
   },
   {
@@ -130,7 +132,7 @@ async function handleTypeText(
         type: "text" as const,
         text: JSON.stringify({
           success: true,
-          typed: parsed.text,
+          typed_length: parsed.text.length,
         }),
       },
     ],

--- a/src/tools/menu.ts
+++ b/src/tools/menu.ts
@@ -11,8 +11,8 @@ import { enqueue } from "../queue.js";
 // -- Schemas -----------------------------------------------------------------
 
 const ClickMenuInputSchema = z.object({
-  app: z.string().describe("Application name"),
-  path: z.string().describe('Menu path, e.g. "File > Save As..."'),
+  app: z.string().max(1_000).describe("Application name"),
+  path: z.string().max(1_000).describe('Menu path, e.g. "File > Save As..."'),
 });
 
 // -- Constants ---------------------------------------------------------------

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -60,6 +60,7 @@ const ScreenshotBaseSchema = z.object({
   window_title: z
     .string()
     .min(1)
+    .max(1_000)
     .optional()
     .describe("Window title to capture (required when mode is window)"),
   max_dimension: z

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -1,4 +1,5 @@
 import { stat, unlink } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
 import { z } from "zod";
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
@@ -11,8 +12,9 @@ import { PERMISSION_CHECK_TIMEOUT_MS } from "../constants.js";
 const ACCESSIBILITY_TEST_SCRIPT =
   'tell application "System Events" to return (exists process 1)';
 
-/** Temporary file used to probe Screen Recording permission. */
-const SCREEN_RECORDING_TEST_PATH = "/tmp/mac-use-mcp-permtest.png";
+/** Generate a unique temporary file path for Screen Recording permission probes. */
+const makeTmpPath = () =>
+  `/tmp/mac-use-mcp-permtest-${randomBytes(8).toString("hex")}.png`;
 
 /** Maximum allowed wait duration (ms). */
 const WAIT_MAX_MS = 10_000;
@@ -88,23 +90,24 @@ async function testAccessibility(): Promise<boolean> {
  * silent screenshot and checking whether the output file has content.
  */
 async function testScreenRecording(): Promise<boolean> {
+  const testPath = makeTmpPath();
   try {
-    await execFileAsync("screencapture", ["-x", SCREEN_RECORDING_TEST_PATH], {
+    await execFileAsync("screencapture", ["-x", testPath], {
       timeout: PERMISSION_CHECK_TIMEOUT_MS,
     });
 
-    const info = await stat(SCREEN_RECORDING_TEST_PATH);
+    const info = await stat(testPath);
     const granted = info.size > 0;
 
     // Clean up test file
-    await unlink(SCREEN_RECORDING_TEST_PATH).catch(() => {
+    await unlink(testPath).catch(() => {
       /* ignore cleanup errors */
     });
 
     return granted;
   } catch {
     // Clean up on failure path as well
-    await unlink(SCREEN_RECORDING_TEST_PATH).catch(() => {
+    await unlink(testPath).catch(() => {
       /* ignore */
     });
     return false;

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -16,6 +16,7 @@ import { enqueue } from "../queue.js";
 const ListWindowsInputSchema = z.object({
   app: z
     .string()
+    .max(1_000)
     .optional()
     .describe(
       "Application name to filter by. If omitted, list windows from all applications.",
@@ -23,9 +24,10 @@ const ListWindowsInputSchema = z.object({
 });
 
 const FocusWindowInputSchema = z.object({
-  app: z.string().describe("Application name to activate."),
+  app: z.string().max(1_000).describe("Application name to activate."),
   title: z
     .string()
+    .max(1_000)
     .optional()
     .describe(
       "Window title to raise. If omitted, the frontmost window of the application is activated.",
@@ -35,6 +37,7 @@ const FocusWindowInputSchema = z.object({
 const OpenApplicationInputSchema = z.object({
   name: z
     .string()
+    .max(1_000)
     .describe(
       'Application name (e.g. "Safari") or bundle identifier (e.g. "com.apple.Safari").',
     ),


### PR DESCRIPTION
## Summary

- Harden `escapeAppleScriptString` — strip C0 control characters (U+0000–U+001F) and DEL (U+007F) before escaping
- Add `.max()` length validation to all string input schemas (prevents abuse via oversized payloads)
- Improve clipboard handling in `type_text` — increase settle delay, return `typed_length` instead of echoing full text, add clipboard loss warning
- Randomize permission test file path to prevent collisions
- Add sensitive data warning to `get_ui_elements` tool description

## Test plan

- [x] 23 new tests added (179 total, all passing)
- [x] Boundary tests for max length validation on every schema
- [x] Control character stripping tests (newline, CR, null, tab, DEL, mixed)
- [ ] CI passes (build + lint + test)