### PR TITLE
refactor: code quality improvements and CLI DX for v1.0.0

### DIFF
--- a/src/__tests__/constants.test.ts
+++ b/src/__tests__/constants.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   KEY_CODES,
-  MODIFIER_FLAGS,
   DEFAULT_MAX_DIMENSION,
   APPLESCRIPT_TIMEOUT_MS,
   CLIPBOARD_TIMEOUT_MS,
-  SCREENCAPTURE_TIMEOUT_MS,
   INPUT_HELPER_TIMEOUT_MS,
   OPEN_COMMAND_TIMEOUT_MS,
   PERMISSION_CHECK_TIMEOUT_MS,
@@ -58,28 +56,6 @@ describe("KEY_CODES", () => {
   });
 });
 
-describe("MODIFIER_FLAGS", () => {
-  it("has exactly 4 entries", () => {
-    expect(Object.keys(MODIFIER_FLAGS)).toHaveLength(4);
-  });
-
-  it("contains expected modifiers", () => {
-    expect(MODIFIER_FLAGS).toHaveProperty("command");
-    expect(MODIFIER_FLAGS).toHaveProperty("shift");
-    expect(MODIFIER_FLAGS).toHaveProperty("option");
-    expect(MODIFIER_FLAGS).toHaveProperty("control");
-  });
-
-  it("all values are distinct positive numbers", () => {
-    const values = Object.values(MODIFIER_FLAGS);
-    const unique = new Set(values);
-    expect(unique.size).toBe(values.length);
-    for (const v of values) {
-      expect(v).toBeGreaterThan(0);
-    }
-  });
-});
-
 describe("DEFAULT_MAX_DIMENSION", () => {
   it("is 0 (no resize)", () => {
     expect(DEFAULT_MAX_DIMENSION).toBe(0);
@@ -91,7 +67,6 @@ describe("timeouts", () => {
     const timeouts = [
       APPLESCRIPT_TIMEOUT_MS,
       CLIPBOARD_TIMEOUT_MS,
-      SCREENCAPTURE_TIMEOUT_MS,
       INPUT_HELPER_TIMEOUT_MS,
       OPEN_COMMAND_TIMEOUT_MS,
       PERMISSION_CHECK_TIMEOUT_MS,
@@ -106,9 +81,7 @@ describe("timeouts", () => {
 describe("ERROR_MESSAGES", () => {
   it("has all expected keys", () => {
     expect(ERROR_MESSAGES).toHaveProperty("TIMEOUT");
-    expect(ERROR_MESSAGES).toHaveProperty("PERMISSION_DENIED");
     expect(ERROR_MESSAGES).toHaveProperty("BINARY_NOT_FOUND");
-    expect(ERROR_MESSAGES).toHaveProperty("INVALID_ARGS");
   });
 
   it("all values are non-empty strings", () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -95,19 +95,6 @@ export const KEY_CODES = {
   Function: 0x3f,
 } as const;
 
-/**
- * CGEvent modifier flag bitmasks.
- *
- * Passed to `CGEventSetFlags` / `CGEventGetFlags` to indicate
- * which modifier keys are held during a keyboard or mouse event.
- */
-export const MODIFIER_FLAGS = {
-  command: 0x100000,
-  shift: 0x020000,
-  option: 0x080000,
-  control: 0x040000,
-} as const;
-
 /** Default maximum dimension (width or height) for screenshot resizing. 0 = no resize. */
 export const DEFAULT_MAX_DIMENSION = 0;
 
@@ -118,9 +105,6 @@ export const APPLESCRIPT_TIMEOUT_MS = 15_000;
 
 /** Timeout for clipboard commands: pbpaste, pbcopy (ms). */
 export const CLIPBOARD_TIMEOUT_MS = 5_000;
-
-/** Timeout for screencapture and sips image-processing commands (ms). */
-export const SCREENCAPTURE_TIMEOUT_MS = 10_000;
 
 /** Timeout for Swift input-helper binary execution (ms). */
 export const INPUT_HELPER_TIMEOUT_MS = 5_000;
@@ -136,9 +120,6 @@ export const PERMISSION_CHECK_TIMEOUT_MS = 5_000;
  */
 export const ERROR_MESSAGES = {
   TIMEOUT: "Operation timed out",
-  PERMISSION_DENIED:
-    "Accessibility permission denied — grant access in System Settings > Privacy & Security > Accessibility",
   BINARY_NOT_FOUND:
     "Required helper binary not found — run `pnpm run build:swift` to compile native helpers",
-  INVALID_ARGS: "Invalid arguments provided to tool",
 } as const;

--- a/src/helpers/screencapture.ts
+++ b/src/helpers/screencapture.ts
@@ -1,5 +1,6 @@
 import { readFile, unlink } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
+import { z } from "zod";
 import { DEFAULT_MAX_DIMENSION } from "../constants.js";
 import { runInputHelper } from "./input-helper.js";
 
@@ -52,18 +53,18 @@ export interface ScreenshotResult {
   scaleY: number;
 }
 
-/** Schema shape for the Swift input-helper screenshot response. */
-interface SwiftScreenshotResponse {
-  success: boolean;
-  base64?: string;
-  width: number;
-  height: number;
-  origin_x: number;
-  origin_y: number;
-  scale_x: number;
-  scale_y: number;
-  error?: string;
-}
+/** Zod schema for validating the Swift input-helper screenshot response. */
+const SwiftScreenshotResponseSchema = z.object({
+  success: z.boolean(),
+  base64: z.string().optional(),
+  width: z.number(),
+  height: z.number(),
+  origin_x: z.number(),
+  origin_y: z.number(),
+  scale_x: z.number(),
+  scale_y: z.number(),
+  error: z.string().optional(),
+});
 
 /**
  * Capture a screenshot via the built-in Swift input-helper.
@@ -119,10 +120,9 @@ async function captureViaInputHelper(
   }
 
   try {
-    const response = (await runInputHelper(
-      "screenshot",
-      helperArgs,
-    )) as unknown as SwiftScreenshotResponse;
+    const response = SwiftScreenshotResponseSchema.parse(
+      await runInputHelper("screenshot", helperArgs),
+    );
 
     if (!response.success) {
       throw new Error(response.error ?? "Screenshot capture failed");

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,56 @@ async function main(): Promise<void> {
   await server.connect(transport);
 }
 
+// -- CLI checks (before server startup) --------------------------------------
+
+const [major] = process.versions.node.split(".").map(Number);
+if (major < 22) {
+  console.error(
+    "mac-use-mcp requires Node.js 22+. Current: " + process.version,
+  );
+  process.exit(1);
+}
+
+const HELP_TEXT = `mac-use-mcp v${version} — MCP server for macOS desktop automation
+
+Usage: mac-use-mcp (launched by an MCP client over stdio)
+
+Options:
+  --version  Print version and exit
+  --help     Show this help message and exit
+
+See https://github.com/antbotlab/mac-use-mcp for documentation.`;
+
+if (process.argv.includes("--version")) {
+  console.log(version);
+  process.exit(0);
+}
+
+if (process.argv.includes("--help")) {
+  console.log(HELP_TEXT);
+  process.exit(0);
+}
+
+const unrecognizedFlag = process.argv
+  .slice(2)
+  .find((arg) => arg.startsWith("--"));
+if (unrecognizedFlag) {
+  console.error(`Unknown flag: ${unrecognizedFlag}\n`);
+  console.error(HELP_TEXT);
+  process.exit(1);
+}
+
+if (process.stdin.isTTY) {
+  console.log(
+    `mac-use-mcp v${version} — MCP server for macOS desktop automation\n` +
+      "This server communicates over stdio and is meant to be launched by an MCP client.\n" +
+      "See https://github.com/antbotlab/mac-use-mcp#install for setup instructions.",
+  );
+  process.exit(0);
+}
+
+// -- Start server ------------------------------------------------------------
+
 main().catch((error: unknown) => {
   process.stderr.write(
     `Fatal: ${error instanceof Error ? error.message : String(error)}\n`,

--- a/src/tools/keyboard.ts
+++ b/src/tools/keyboard.ts
@@ -76,12 +76,20 @@ export const keyboardToolDefinitions: Tool[] = [
     description:
       'Type text at the current cursor position using clipboard paste. Supports full Unicode including CJK characters and emoji. Temporarily replaces clipboard contents. Non-text clipboard content (images, files) will be lost permanently. If secure input is active (e.g. password fields), returns a note suggesting clipboard_write + press_key("cmd+v") as an alternative.',
     inputSchema: zodToToolInputSchema(TypeTextInputSchema),
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+    },
   },
   {
     name: "press_key",
     description:
       'Simulate a key press with optional modifiers. Accepts a key combo string like "cmd+c", "ctrl+shift+F5", or "Return". Modifiers: cmd, ctrl, shift, opt/alt.',
     inputSchema: zodToToolInputSchema(PressKeyInputSchema),
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+    },
   },
 ];
 
@@ -112,7 +120,10 @@ async function handleTypeText(
   // Paste via AppleScript Cmd+V
   await execFileAsync(
     "osascript",
-    ["-e", 'tell application "System Events" to key code 9 using command down'],
+    [
+      "-e",
+      `tell application "System Events" to key code ${KEY_CODES.v} using command down`,
+    ],
     { timeout: APPLESCRIPT_TIMEOUT_MS },
   );
 

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -5,6 +5,7 @@ import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { zodToToolInputSchema } from "../helpers/schema.js";
 import { execFileAsync } from "../helpers/exec.js";
 import { PERMISSION_CHECK_TIMEOUT_MS } from "../constants.js";
+import { enqueue } from "../queue.js";
 
 // -- Constants ---------------------------------------------------------------
 
@@ -170,6 +171,6 @@ export const utilityToolHandlers: Record<
   string,
   (args: Record<string, unknown>) => Promise<CallToolResult>
 > = {
-  check_permissions: () => handleCheckPermissions(),
+  check_permissions: () => enqueue(() => handleCheckPermissions()),
   wait: handleWait,
 };

--- a/src/tools/window.ts
+++ b/src/tools/window.ts
@@ -102,7 +102,7 @@ export const windowToolDefinitions: Tool[] = [
     inputSchema: zodToToolInputSchema(OpenApplicationInputSchema),
     annotations: {
       readOnlyHint: false,
-      destructiveHint: false,
+      destructiveHint: true,
     },
   },
 ];


### PR DESCRIPTION
## Summary

- Add missing `annotations` to `type_text`, `press_key` (`destructiveHint: true`); fix `open_application` annotation
- Route `check_permissions` through serial queue to prevent race conditions
- Replace magic `key code 9` with `KEY_CODES.v` constant
- Replace unsafe `as unknown as` cast with Zod schema validation for Swift screenshot response
- Remove dead exports: `MODIFIER_FLAGS`, `SCREENCAPTURE_TIMEOUT_MS`, unused `ERROR_MESSAGES` keys
- Add Node.js 22+ runtime check, `--version`, `--help` flags, unrecognized flag handling, and TTY detection

## Test plan

- [x] 176 tests pass (3 removed for dead constant tests)
- [x] Lint and Prettier clean
- [x] Build succeeds
- [ ] CI passes