### PR TITLE
chore: universal binary, CI hardening, and v1.0.0 publish prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
@@ -23,6 +23,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build:swift
       - run: pnpm run build
+      - run: pnpm test
       - run: pnpm publish --provenance --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-03-01
+
+### Security
+- AppleScript string sanitization: strip all C0 control characters (U+0000–U+001F) and DEL (U+007F) before escaping
+- Input length limits (`.max()`) on all string input schemas to prevent abuse
+- Randomized temp paths for permission test files
+- `type_text` description warns that clipboard contents are temporarily replaced
+- `get_ui_elements` description warns about potential sensitive data exposure
+
 ### Added
+- `--version` and `--help` CLI flags
+- TTY detection with helpful message when run interactively
+- Node.js 22+ runtime version check
+- Annotations (`readOnlyHint`, `destructiveHint`) on keyboard tools
+- Zod validation for Swift screenshot responses (replaces `as unknown as` cast)
+- Universal binary (arm64 + x86_64) for Intel and Apple Silicon Macs
+- `.prettierrc` with default config
 - Unit test suite: 156 tests across 15 files covering schema validation, tool registration, error handling, pure helpers, and queue behavior
-- Vitest test runner with CI integration (`pnpm test` step in GitHub Actions)
-- `tsconfig.build.json` to separate build and type-check concerns (test files excluded from `dist/`)
+- Vitest test runner with CI integration
+- `tsconfig.build.json` to separate build and type-check concerns
 
 ### Changed
-- Build script uses `tsconfig.build.json` (`tsc -p tsconfig.build.json`) to exclude test files from output
-- Export pure helper functions for direct unit testing: `parseAppleScriptError`, `matchProcessName`, `scrollDirectionToDeltas`, `isBundleId`, `buildMenuClickScript`
+- `type_text` returns `typed_length` instead of echoing full text in response
+- `PASTE_SETTLE_MS` increased from 50ms to 100ms for clipboard reliability
+- `open_application` annotation corrected: `destructiveHint: true`
+- `check_permissions` routed through serial queue for correctness
+- Build script uses `tsconfig.build.json` to exclude test files from output
+- Export pure helper functions for direct unit testing
+
+### Removed
+- Legacy `screencapture` CLI fallback (~160 lines) — Swift binary is the sole capture path
+- Dead constants: `MODIFIER_FLAGS`, `SCREENCAPTURE_TIMEOUT_MS`, unused `ERROR_MESSAGES` entries
+
+### Fixed
+- Demo GIF renders on npm (absolute URL)
+- `package.json` description aligned with README ("Zero-native-dependency")
+
+### Docs
+- CONTRIBUTING.md: added test scripts (`pnpm test`, `pnpm test:watch`)
+- PR template: added test checklist item
+- README: permission caveat on "just works" tagline, macOS-only install note
 
 ## [0.2.0] - 2026-03-01
 
@@ -68,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI workflow for macOS
 - Open-source community files (contributing guide, code of conduct, security policy)
 
-[Unreleased]: https://github.com/antbotlab/mac-use-mcp/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/antbotlab/mac-use-mcp/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/antbotlab/mac-use-mcp/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/antbotlab/mac-use-mcp/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/antbotlab/mac-use-mcp/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mac-use-mcp",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Zero-native-dependency macOS desktop automation via MCP",
   "license": "MIT",
   "author": "antbotlab",
@@ -23,7 +23,7 @@
     "test:watch": "vitest",
     "lint": "eslint src/",
     "format": "prettier --write src/",
-    "prepublishOnly": "pnpm run build:swift && pnpm run build"
+    "prepublishOnly": "pnpm run build:swift && pnpm run build && pnpm test"
   },
   "files": [
     "dist/",

--- a/scripts/build-swift.sh
+++ b/scripts/build-swift.sh
@@ -6,10 +6,25 @@ mkdir -p dist/bin
 # Target macOS 13 (Ventura) — the project's minimum supported version.
 # This also suppresses the "obsoleted" error for CGWindowListCreateImage
 # on macOS 15+ SDKs, where the API is deprecated but still functional.
+
+# Compile for both architectures
 swiftc swift/input-helper.swift \
-  -o dist/bin/input-helper \
+  -o dist/bin/input-helper-arm64 \
   -O \
-  -target "$(uname -m)-apple-macos13.0"
+  -target arm64-apple-macos13.0
+
+swiftc swift/input-helper.swift \
+  -o dist/bin/input-helper-x86_64 \
+  -O \
+  -target x86_64-apple-macos13.0
+
+# Combine into universal binary
+lipo -create -output dist/bin/input-helper \
+  dist/bin/input-helper-arm64 \
+  dist/bin/input-helper-x86_64
+
+# Clean up architecture-specific binaries
+rm dist/bin/input-helper-arm64 dist/bin/input-helper-x86_64
 
 chmod +x dist/bin/input-helper
-echo "Swift helper compiled successfully"
+echo "Swift helper compiled successfully (universal binary: arm64 + x86_64)"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "declarationMap": false,
+    "declaration": false
+  },
   "exclude": ["node_modules", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
## Summary

- Universal binary (arm64 + x86_64) via `lipo` — supports both Intel and Apple Silicon Macs
- Pin pnpm version to 10 in CI and release workflows for reproducible builds
- Disable source maps and declarations in build config (CLI tool, no downstream TS consumers)
- Add `pnpm test` to `prepublishOnly` and as a dedicated CI step before publish
- Bump version to 1.0.0 with comprehensive CHANGELOG

## Test plan

- [x] `file dist/bin/input-helper` confirms `Mach-O universal binary with 2 architectures`
- [x] Binary executes successfully on arm64
- [x] `pnpm pack` produces 97KB tarball with correct contents
- [x] `head -1 dist/index.js` shows shebang
- [x] 176 tests pass, lint and prettier clean
- [ ] CI passes