### PR TITLE
fix: screenshot origin, window filtering, error messages, and off-screen warnings (P1-P2)

### DIFF
--- a/src/__tests__/helpers/input-helper.test.ts
+++ b/src/__tests__/helpers/input-helper.test.ts
@@ -117,8 +117,7 @@ describe("runInputHelper", () => {
   it("propagates error message from stdout JSON on non-zero exit", async () => {
     mockExecFileAsync.mockRejectedValue(
       makeExecError("Command failed", {
-        stdout:
-          '{"success":false,"error":"no window found matching \'foo\'"}',
+        stdout: '{"success":false,"error":"no window found matching \'foo\'"}',
         stderr: "",
         code: 1,
       }),

--- a/src/__tests__/helpers/input-helper.test.ts
+++ b/src/__tests__/helpers/input-helper.test.ts
@@ -1,67 +1,159 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { runInputHelper } from "../../helpers/input-helper.js";
+import { ERROR_MESSAGES } from "../../constants.js";
 
-// Mock the exec helper
+// Mock dependencies
 vi.mock("../../helpers/exec.js", () => ({
   execFileAsync: vi.fn(),
 }));
 
-// Mock fs access check (binary existence)
 vi.mock("node:fs/promises", () => ({
-  access: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn(),
 }));
 
 import { execFileAsync } from "../../helpers/exec.js";
+import { access } from "node:fs/promises";
+import { runInputHelper } from "../../helpers/input-helper.js";
 
 const mockExecFileAsync = vi.mocked(execFileAsync);
+const mockAccess = vi.mocked(access);
+
+/** Create an exec-style error with stdout, stderr, code, killed, signal fields. */
+function makeExecError(
+  message: string,
+  fields: {
+    stdout?: string;
+    stderr?: string;
+    code?: number;
+    killed?: boolean;
+    signal?: string;
+  },
+): Error {
+  return Object.assign(new Error(message), fields) as Error;
+}
 
 describe("runInputHelper", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    // By default, the binary exists
+    mockAccess.mockResolvedValue(undefined);
   });
 
-  it("propagates error message from stdout JSON on non-zero exit", async () => {
-    const execError = Object.assign(new Error("Command failed"), {
-      stdout: '{"success":false,"error":"no window found matching \'foo\'"}',
+  it("throws BINARY_NOT_FOUND when binary is missing", async () => {
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+
+    await expect(runInputHelper("click", { x: 0, y: 0 })).rejects.toThrow(
+      ERROR_MESSAGES.BINARY_NOT_FOUND,
+    );
+  });
+
+  it("returns parsed JSON on success", async () => {
+    const response = { success: true, x: 100, y: 200 };
+    mockExecFileAsync.mockResolvedValue({
+      stdout: JSON.stringify(response),
       stderr: "",
-      code: 1,
-      killed: false,
-      signal: null,
     });
-    mockExecFileAsync.mockRejectedValueOnce(execError);
+
+    const result = await runInputHelper("cursor", {});
+    expect(result).toEqual(response);
+  });
+
+  it("passes command and JSON args to binary", async () => {
+    mockExecFileAsync.mockResolvedValue({
+      stdout: '{"success": true}',
+      stderr: "",
+    });
+
+    await runInputHelper("click", { x: 10, y: 20 });
+
+    expect(mockExecFileAsync).toHaveBeenCalledWith(
+      expect.stringContaining("input-helper"),
+      ["click", '{"x":10,"y":20}'],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it("throws TIMEOUT when killed by SIGTERM", async () => {
+    mockExecFileAsync.mockRejectedValue(
+      makeExecError("killed", { killed: true, signal: "SIGTERM", stderr: "" }),
+    );
+
+    await expect(runInputHelper("click", {})).rejects.toThrow(
+      ERROR_MESSAGES.TIMEOUT,
+    );
+  });
+
+  it("throws descriptive error on invalid JSON response", async () => {
+    mockExecFileAsync.mockResolvedValue({
+      stdout: "not json at all",
+      stderr: "",
+    });
+
+    await expect(runInputHelper("cursor", {})).rejects.toThrow(/invalid JSON/);
+  });
+
+  it("forwards stderr as error message", async () => {
+    mockExecFileAsync.mockRejectedValue(
+      makeExecError("exec failed", {
+        stderr: "Permission denied for accessibility",
+        code: 1,
+      }),
+    );
+
+    await expect(runInputHelper("click", {})).rejects.toThrow(
+      /Permission denied for accessibility/,
+    );
+  });
+
+  it("uses exit code when stderr is empty", async () => {
+    mockExecFileAsync.mockRejectedValue(
+      makeExecError("exec failed", { stderr: "", code: 42 }),
+    );
+
+    await expect(runInputHelper("click", {})).rejects.toThrow(/exit code 42/);
+  });
+
+  // -- Tests for stdout JSON error propagation (Step 5) ----------------------
+
+  it("propagates error message from stdout JSON on non-zero exit", async () => {
+    mockExecFileAsync.mockRejectedValue(
+      makeExecError("Command failed", {
+        stdout:
+          '{"success":false,"error":"no window found matching \'foo\'"}',
+        stderr: "",
+        code: 1,
+      }),
+    );
 
     await expect(runInputHelper("screenshot", {})).rejects.toThrow(
       "no window found matching 'foo'",
     );
   });
 
-  it("falls back to generic message when stdout has no error field", async () => {
-    const execError = Object.assign(new Error("Command failed"), {
-      stdout: "not json",
-      stderr: "",
-      code: 1,
-      killed: false,
-      signal: null,
-    });
-    mockExecFileAsync.mockRejectedValueOnce(execError);
+  it("falls back to exit code when stdout is not valid JSON", async () => {
+    mockExecFileAsync.mockRejectedValue(
+      makeExecError("Command failed", {
+        stdout: "not json",
+        stderr: "",
+        code: 1,
+      }),
+    );
 
     await expect(runInputHelper("screenshot", {})).rejects.toThrow(
       "Input helper failed with exit code 1",
     );
   });
 
-  it("uses stderr when available", async () => {
-    const execError = Object.assign(new Error("Command failed"), {
-      stdout: "",
-      stderr: "some stderr message",
-      code: 1,
-      killed: false,
-      signal: null,
-    });
-    mockExecFileAsync.mockRejectedValueOnce(execError);
+  it("prefers stdout JSON error over stderr", async () => {
+    mockExecFileAsync.mockRejectedValue(
+      makeExecError("Command failed", {
+        stdout: '{"success":false,"error":"specific swift error"}',
+        stderr: "generic stderr noise",
+        code: 1,
+      }),
+    );
 
     await expect(runInputHelper("screenshot", {})).rejects.toThrow(
-      "some stderr message",
+      "specific swift error",
     );
   });
 });

--- a/src/__tests__/helpers/input-helper.test.ts
+++ b/src/__tests__/helpers/input-helper.test.ts
@@ -1,108 +1,67 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { ERROR_MESSAGES } from "../../constants.js";
+import { runInputHelper } from "../../helpers/input-helper.js";
 
-// Mock dependencies
+// Mock the exec helper
 vi.mock("../../helpers/exec.js", () => ({
   execFileAsync: vi.fn(),
 }));
 
+// Mock fs access check (binary existence)
 vi.mock("node:fs/promises", () => ({
-  access: vi.fn(),
+  access: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { execFileAsync } from "../../helpers/exec.js";
-import { access } from "node:fs/promises";
-import { runInputHelper } from "../../helpers/input-helper.js";
 
 const mockExecFileAsync = vi.mocked(execFileAsync);
-const mockAccess = vi.mocked(access);
-
-/** Create an exec-style error with stderr, code, killed, signal fields. */
-function makeExecError(
-  message: string,
-  fields: { stderr?: string; code?: number; killed?: boolean; signal?: string },
-): Error {
-  return Object.assign(new Error(message), fields) as Error;
-}
 
 describe("runInputHelper", () => {
   beforeEach(() => {
-    vi.resetAllMocks();
-    // By default, the binary exists
-    mockAccess.mockResolvedValue(undefined);
+    vi.clearAllMocks();
   });
 
-  it("throws BINARY_NOT_FOUND when binary is missing", async () => {
-    mockAccess.mockRejectedValue(new Error("ENOENT"));
-
-    await expect(runInputHelper("click", { x: 0, y: 0 })).rejects.toThrow(
-      ERROR_MESSAGES.BINARY_NOT_FOUND,
-    );
-  });
-
-  it("returns parsed JSON on success", async () => {
-    const response = { success: true, x: 100, y: 200 };
-    mockExecFileAsync.mockResolvedValue({
-      stdout: JSON.stringify(response),
+  it("propagates error message from stdout JSON on non-zero exit", async () => {
+    const execError = Object.assign(new Error("Command failed"), {
+      stdout: '{"success":false,"error":"no window found matching \'foo\'"}',
       stderr: "",
+      code: 1,
+      killed: false,
+      signal: null,
     });
+    mockExecFileAsync.mockRejectedValueOnce(execError);
 
-    const result = await runInputHelper("cursor", {});
-    expect(result).toEqual(response);
+    await expect(runInputHelper("screenshot", {})).rejects.toThrow(
+      "no window found matching 'foo'",
+    );
   });
 
-  it("passes command and JSON args to binary", async () => {
-    mockExecFileAsync.mockResolvedValue({
-      stdout: '{"success": true}',
+  it("falls back to generic message when stdout has no error field", async () => {
+    const execError = Object.assign(new Error("Command failed"), {
+      stdout: "not json",
       stderr: "",
+      code: 1,
+      killed: false,
+      signal: null,
     });
+    mockExecFileAsync.mockRejectedValueOnce(execError);
 
-    await runInputHelper("click", { x: 10, y: 20 });
-
-    expect(mockExecFileAsync).toHaveBeenCalledWith(
-      expect.stringContaining("input-helper"),
-      ["click", '{"x":10,"y":20}'],
-      expect.objectContaining({ timeout: expect.any(Number) }),
+    await expect(runInputHelper("screenshot", {})).rejects.toThrow(
+      "Input helper failed with exit code 1",
     );
   });
 
-  it("throws TIMEOUT when killed by SIGTERM", async () => {
-    mockExecFileAsync.mockRejectedValue(
-      makeExecError("killed", { killed: true, signal: "SIGTERM", stderr: "" }),
-    );
-
-    await expect(runInputHelper("click", {})).rejects.toThrow(
-      ERROR_MESSAGES.TIMEOUT,
-    );
-  });
-
-  it("throws descriptive error on invalid JSON response", async () => {
-    mockExecFileAsync.mockResolvedValue({
-      stdout: "not json at all",
-      stderr: "",
+  it("uses stderr when available", async () => {
+    const execError = Object.assign(new Error("Command failed"), {
+      stdout: "",
+      stderr: "some stderr message",
+      code: 1,
+      killed: false,
+      signal: null,
     });
+    mockExecFileAsync.mockRejectedValueOnce(execError);
 
-    await expect(runInputHelper("cursor", {})).rejects.toThrow(/invalid JSON/);
-  });
-
-  it("forwards stderr as error message", async () => {
-    mockExecFileAsync.mockRejectedValue(
-      makeExecError("exec failed", {
-        stderr: "Permission denied for accessibility",
-        code: 1,
-      }),
+    await expect(runInputHelper("screenshot", {})).rejects.toThrow(
+      "some stderr message",
     );
-
-    await expect(runInputHelper("click", {})).rejects.toThrow(
-      /Permission denied for accessibility/,
-    );
-  });
-
-  it("uses exit code when stderr is empty", async () => {
-    mockExecFileAsync.mockRejectedValue(
-      makeExecError("exec failed", { stderr: "", code: 42 }),
-    );
-
-    await expect(runInputHelper("click", {})).rejects.toThrow(/exit code 42/);
   });
 });

--- a/src/helpers/input-helper.ts
+++ b/src/helpers/input-helper.ts
@@ -55,6 +55,7 @@ export async function runInputHelper(
     return JSON.parse(stdout) as Record<string, unknown>;
   } catch (error: unknown) {
     const execError = error as {
+      stdout?: string;
       stderr?: string;
       code?: number | string;
       killed?: boolean;
@@ -70,6 +71,23 @@ export async function runInputHelper(
       throw new Error(`Input helper returned invalid JSON: ${error.message}`, {
         cause: error,
       });
+    }
+
+    // Swift fail() writes {"success":false,"error":"..."} to stdout before exit(1).
+    // Parse it to surface the actual error message.
+    const stdout = execError.stdout?.trim() ?? "";
+    if (stdout) {
+      try {
+        const parsed = JSON.parse(stdout) as Record<string, unknown>;
+        if (typeof parsed.error === "string") {
+          throw new Error(parsed.error, { cause: error });
+        }
+      } catch (parseErr) {
+        // Re-throw if it's our structured error; otherwise fall through
+        if (parseErr instanceof Error && parseErr.cause === error) {
+          throw parseErr;
+        }
+      }
     }
 
     const stderr = execError.stderr?.trim() ?? "";

--- a/src/tools/mouse.ts
+++ b/src/tools/mouse.ts
@@ -197,7 +197,7 @@ async function handleClick(
 ): Promise<CallToolResult> {
   const parsed = ClickInputSchema.parse(args);
 
-  await runInputHelper("click", {
+  const result = await runInputHelper("click", {
     x: parsed.x,
     y: parsed.y,
     button: parsed.button,
@@ -207,18 +207,18 @@ async function handleClick(
       : {}),
   });
 
+  const response: Record<string, unknown> = {
+    clicked: { x: parsed.x, y: parsed.y },
+    button: parsed.button,
+    click_count: parsed.click_count,
+    modifiers: parsed.modifiers ?? [],
+  };
+  if (typeof result.warning === "string") {
+    response.warning = result.warning;
+  }
+
   return {
-    content: [
-      {
-        type: "text" as const,
-        text: JSON.stringify({
-          clicked: { x: parsed.x, y: parsed.y },
-          button: parsed.button,
-          click_count: parsed.click_count,
-          modifiers: parsed.modifiers ?? [],
-        }),
-      },
-    ],
+    content: [{ type: "text" as const, text: JSON.stringify(response) }],
   };
 }
 
@@ -228,15 +228,17 @@ async function handleMoveMouse(
 ): Promise<CallToolResult> {
   const parsed = MoveMouseInputSchema.parse(args);
 
-  await runInputHelper("move", { x: parsed.x, y: parsed.y });
+  const result = await runInputHelper("move", { x: parsed.x, y: parsed.y });
+
+  const response: Record<string, unknown> = {
+    moved_to: { x: parsed.x, y: parsed.y },
+  };
+  if (typeof result.warning === "string") {
+    response.warning = result.warning;
+  }
 
   return {
-    content: [
-      {
-        type: "text" as const,
-        text: JSON.stringify({ moved_to: { x: parsed.x, y: parsed.y } }),
-      },
-    ],
+    content: [{ type: "text" as const, text: JSON.stringify(response) }],
   };
 }
 
@@ -269,24 +271,24 @@ async function handleScroll(
   const parsed = ScrollInputSchema.parse(args);
   const { dx, dy } = scrollDirectionToDeltas(parsed.direction, parsed.amount);
 
-  await runInputHelper("scroll", {
+  const result = await runInputHelper("scroll", {
     x: parsed.x,
     y: parsed.y,
     dx,
     dy,
   });
 
+  const response: Record<string, unknown> = {
+    scrolled_at: { x: parsed.x, y: parsed.y },
+    direction: parsed.direction,
+    amount: parsed.amount,
+  };
+  if (typeof result.warning === "string") {
+    response.warning = result.warning;
+  }
+
   return {
-    content: [
-      {
-        type: "text" as const,
-        text: JSON.stringify({
-          scrolled_at: { x: parsed.x, y: parsed.y },
-          direction: parsed.direction,
-          amount: parsed.amount,
-        }),
-      },
-    ],
+    content: [{ type: "text" as const, text: JSON.stringify(response) }],
   };
 }
 
@@ -296,7 +298,7 @@ async function handleDrag(
 ): Promise<CallToolResult> {
   const parsed = DragInputSchema.parse(args);
 
-  await runInputHelper("drag", {
+  const result = await runInputHelper("drag", {
     sx: parsed.start_x,
     sy: parsed.start_y,
     ex: parsed.end_x,
@@ -304,19 +306,19 @@ async function handleDrag(
     duration: parsed.duration_ms,
   });
 
+  const response: Record<string, unknown> = {
+    dragged: {
+      from: { x: parsed.start_x, y: parsed.start_y },
+      to: { x: parsed.end_x, y: parsed.end_y },
+    },
+    duration_ms: parsed.duration_ms,
+  };
+  if (typeof result.warning === "string") {
+    response.warning = result.warning;
+  }
+
   return {
-    content: [
-      {
-        type: "text" as const,
-        text: JSON.stringify({
-          dragged: {
-            from: { x: parsed.start_x, y: parsed.start_y },
-            to: { x: parsed.end_x, y: parsed.end_y },
-          },
-          duration_ms: parsed.duration_ms,
-        }),
-      },
-    ],
+    content: [{ type: "text" as const, text: JSON.stringify(response) }],
   };
 }
 

--- a/swift/input-helper.swift
+++ b/swift/input-helper.swift
@@ -57,16 +57,18 @@ func applyModifiers(_ event: CGEvent, _ modifiers: [String]) {
 
 // MARK: - Bounds Check Helper
 
-/// Check whether a point is within any active display's bounds.
+/// Check whether a point falls within the union bounding rect of all active displays.
 ///
-/// Returns a warning string if the point is outside all screens, or nil if within bounds.
+/// Returns a warning string if the point is outside the combined screen area,
+/// or nil if within bounds. Note: for non-contiguous multi-monitor layouts,
+/// points in gaps between displays may not trigger a warning.
 func offScreenWarning(x: CGFloat, y: CGFloat) -> String? {
     let bounds = logicalScreenBounds()
     let point = CGPoint(x: x, y: y)
     if bounds.contains(point) {
         return nil
     }
-    return "Coordinates (\(Int(x)), \(Int(y))) are outside all screen bounds \(Int(bounds.origin.x)),\(Int(bounds.origin.y)) \(Int(bounds.size.width))x\(Int(bounds.size.height))"
+    return "Coordinates (\(Int(x)), \(Int(y))) are outside all screen bounds (\(Int(bounds.origin.x)), \(Int(bounds.origin.y))) size \(Int(bounds.size.width))x\(Int(bounds.size.height))"
 }
 
 // MARK: - Pointer Command Handlers

--- a/swift/input-helper.swift
+++ b/swift/input-helper.swift
@@ -543,13 +543,17 @@ func handleListWindows(_ args: [String: Any]) {
             continue
         }
 
-        // Skip tiny/invisible windows
-        if width < 1 || height < 1 { continue }
+        // Skip tiny/invisible windows (below 10×10 are system artifacts)
+        if width < 10 || height < 10 { continue }
 
         // Apply app filter
         if let filter = filterApp, ownerName != filter { continue }
 
         let title = window[kCGWindowName as String] as? String ?? ""
+
+        // When no app filter: skip empty-title windows (system services)
+        if filterApp == nil && title.isEmpty { continue }
+
         let isOnscreen = window[kCGWindowIsOnscreen as String] as? Bool ?? false
 
         windows.append([

--- a/swift/input-helper.swift
+++ b/swift/input-helper.swift
@@ -55,6 +55,20 @@ func applyModifiers(_ event: CGEvent, _ modifiers: [String]) {
     event.flags = CGEventFlags(rawValue: rawFlags)
 }
 
+// MARK: - Bounds Check Helper
+
+/// Check whether a point is within any active display's bounds.
+///
+/// Returns a warning string if the point is outside all screens, or nil if within bounds.
+func offScreenWarning(x: CGFloat, y: CGFloat) -> String? {
+    let bounds = logicalScreenBounds()
+    let point = CGPoint(x: x, y: y)
+    if bounds.contains(point) {
+        return nil
+    }
+    return "Coordinates (\(Int(x)), \(Int(y))) are outside all screen bounds \(Int(bounds.origin.x)),\(Int(bounds.origin.y)) \(Int(bounds.size.width))x\(Int(bounds.size.height))"
+}
+
 // MARK: - Pointer Command Handlers
 
 /// Inter-event delay (microseconds) between click pairs so macOS recognizes
@@ -144,7 +158,11 @@ func handleClick(_ args: [String: Any]) {
         }
     }
 
-    outputJSON(["success": true])
+    var result: [String: Any] = ["success": true]
+    if let warning = offScreenWarning(x: x, y: y) {
+        result["warning"] = warning
+    }
+    outputJSON(result)
 }
 
 /// Handle the "move" command.
@@ -166,7 +184,12 @@ func handleMove(_ args: [String: Any]) {
     }
 
     event.post(tap: .cghidEventTap)
-    outputJSON(["success": true])
+
+    var result: [String: Any] = ["success": true]
+    if let warning = offScreenWarning(x: x, y: y) {
+        result["warning"] = warning
+    }
+    outputJSON(result)
 }
 
 /// Handle the "cursor" command.
@@ -375,7 +398,11 @@ func handleScroll(_ args: [String: Any]) {
     }
     scrollEvent.post(tap: .cghidEventTap)
 
-    outputJSON(["success": true])
+    var result: [String: Any] = ["success": true]
+    if let warning = offScreenWarning(x: x, y: y) {
+        result["warning"] = warning
+    }
+    outputJSON(result)
 }
 
 // MARK: - Drag Command Handler
@@ -446,7 +473,15 @@ func handleDrag(_ args: [String: Any]) {
     }
     upEvent.post(tap: .cghidEventTap)
 
-    outputJSON(["success": true])
+    var result: [String: Any] = ["success": true]
+    // Check both start and end points
+    var warnings: [String] = []
+    if let w = offScreenWarning(x: sx, y: sy) { warnings.append("start: \(w)") }
+    if let w = offScreenWarning(x: ex, y: ey) { warnings.append("end: \(w)") }
+    if !warnings.isEmpty {
+        result["warning"] = warnings.joined(separator: "; ")
+    }
+    outputJSON(result)
 }
 
 // MARK: - Secure Input Status Handler


### PR DESCRIPTION
## Summary

Fixes 4 issues (P1-P2) discovered during functional testing on a dual-monitor macOS setup:

- **Full-screen screenshot origin always (0,0)** [P1]: \`screenshot(mode: "full")\` returned \`origin_x: 0, origin_y: 0\` regardless of display layout, breaking coordinate mapping for secondary displays. Fix: capture actual \`screenBounds.origin\` in the full-screen code path.

- **list_windows returns excessive system windows** [P1]: Unfiltered \`list_windows\` returned 91+ entries including invisible system services. Fix: raise minimum size filter from 1×1 to 10×10, skip empty-title windows when no app filter is specified (app-filtered queries still return all windows for that app).

- **Window screenshot error message unclear** [P2]: \`screenshot(mode: "window", window_title: "NonExistent")\` returned generic "exit code 1" instead of Swift's actual error. Root cause: Swift \`fail()\` writes structured JSON to stdout, but the catch block only checked stderr. Fix: parse \`execError.stdout\` as JSON before falling back to stderr.

- **Off-screen coordinates silently accepted** [P2]: \`click(x: 99999, y: 99999)\` returned success with no feedback. Fix: add \`offScreenWarning()\` helper in Swift that checks coordinates against the union bounding rect of all displays, returning a warning field (not an error) when coordinates fall outside. Applied to click, move, scroll, and drag handlers. TS handlers forward the warning field.

## Changes

- `swift/input-helper.swift`: Fix screenshot origin, list_windows filtering, add offScreenWarning helper
- `src/helpers/input-helper.ts`: Parse stdout JSON error before stderr fallback
- `src/tools/mouse.ts`: Forward warning field from all 4 mouse handlers
- `src/__tests__/helpers/input-helper.test.ts`: Add 3 new tests for stdout error propagation (10 total)

## Test plan

- [x] `pnpm build && pnpm test` — 179 tests pass
- [x] `pnpm lint` — clean
- [ ] Functional: `screenshot(mode: "full")` returns correct origin on dual monitors
- [ ] Functional: `list_windows()` returns manageable count (< 20 typical)
- [ ] Functional: `screenshot(mode: "window", window_title: "NonExistent")` shows "no window found matching"
- [ ] Functional: `click(x: 99999, y: 99999)` returns success with warning
- [ ] Functional: `click(x: 500, y: 500)` returns success without warning