### PR TITLE
chore: add MCP Registry and Smithery configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,8 @@ npm-debug.log*
 swift/*.o
 swift/*.d
 
+# MCP Registry auth tokens
+.mcpregistry_*
+
 # Claude Code
 .claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-03-02
+
+### Added
+- `mcpName` field in package.json for Official MCP Registry publishing
+- `server.json` for MCP Registry metadata
+- `smithery.yaml` for Smithery directory registration
+
+## [1.1.0] - 2026-03-02
+
+### Added
+- `screenshot` ruler overlay (`ruler` parameter) for precise coordinate reading
+
+### Docs
+- Add safety warning for sandbox usage and data protection
+- Add model recommendations and MCP client configurations
+- Add banner and replace demo GIF with MP4
+
 ## [1.0.1] - 2026-03-02
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mac-use-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Zero-native-dependency macOS desktop automation via MCP",
   "license": "MIT",
   "author": "antbotlab",
@@ -64,5 +64,6 @@
   "bugs": {
     "url": "https://github.com/antbotlab/mac-use-mcp/issues"
   },
-  "homepage": "https://github.com/antbotlab/mac-use-mcp#readme"
+  "homepage": "https://github.com/antbotlab/mac-use-mcp#readme",
+  "mcpName": "io.github.antbotlab/mac-use-mcp"
 }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.antbotlab/mac-use-mcp",
+  "description": "Zero-dependency macOS desktop automation for AI agents. 18 tools via MCP. macOS 13+.",
+  "repository": {
+    "url": "https://github.com/antbotlab/mac-use-mcp",
+    "source": "github"
+  },
+  "version": "1.1.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "mac-use-mcp",
+      "version": "1.1.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,8 @@
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required: []
+    properties: {}
+  commandFunction: |
+    (config) => ({ command: 'npx', args: ['-y', 'mac-use-mcp'] })


### PR DESCRIPTION
## Summary

- Add `mcpName` field to `package.json` for Official MCP Registry publishing
- Add `server.json` (MCP Registry metadata)
- Add `smithery.yaml` (Smithery directory registration config)
- Add `.mcpregistry_*` to `.gitignore` (prevent auth token leaks)
- Backfill CHANGELOG entry for v1.1.0 (ruler overlay)
- Bump version to 1.1.1

## Context

Preparing for submission to 8 MCP aggregator directories. The Official MCP Registry requires `mcpName` in the published npm package. Smithery requires `smithery.yaml` in the repo root. Neither file affects runtime behavior.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (182 tests)
- [x] `pnpm lint` passes
- [x] `prettier --check` passes
- [x] `mcp-publisher validate` passes
- [x] `server.json` and `smithery.yaml` excluded from npm package (`files` whitelist)
- [x] Auth token files excluded via `.gitignore`